### PR TITLE
fix: media path traversal and SSRF protection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,13 @@ All tools/prompts/resources are providers auto-discovered by `@rekog/mcp-nest`. 
 - `@/*` → `src/*`
 - `@test/*` → `test/*`
 
+### Key Dependencies
+
+- **Zod v4** (`zod@^4.x`) — NOT v3. Zod 4 has different APIs (e.g., `z.interface()`, changed error handling). Don't use v3 patterns.
+- **`@modelcontextprotocol/sdk`** — Pinned to exact version (`1.28.0`). Don't bump without testing MCP protocol compatibility.
+- **TypeScript** — `strict: true`, `module: "nodenext"`, target `ES2023`. Path aliases (`@/`, `@test/`) handle most imports.
+- **ESLint** — Flat config (`eslint.config.mjs`), not legacy `.eslintrc`.
+
 ## Adding New Tools
 
 ### Essential Tools (general Anki operations)
@@ -104,6 +111,8 @@ All tools/prompts/resources are providers auto-discovered by `@rekog/mcp-nest`. 
 **Note**: `ESSENTIAL_MCP_TOOLS` contains tools, prompts, and resources that MCP-Nest discovers. The separate `ESSENTIAL_MCP_PRIMITIVES` array adds infrastructure like `AnkiConnectClient`.
 
 For multi-action tools, use the action tool pattern: create a directory with `index.ts`, `yourTool.tool.ts`, and `actions/*.action.ts` files. See `deckActions/` for reference.
+
+For tools with complex output schemas, extract Zod types into a `*.types.ts` file alongside the tool (see `collection-stats/collection-stats.types.ts` and `review-stats/review-stats.types.ts`).
 
 ### GUI Tools (interface operations)
 

--- a/README.md
+++ b/README.md
@@ -368,6 +368,9 @@ For more details, see the [official MCP documentation](https://modelcontextproto
 | `ANKI_CONNECT_API_KEY` | API key if configured in AnkiConnect | - |
 | `ANKI_CONNECT_TIMEOUT` | Request timeout in ms | `5000` |
 | `READ_ONLY` | Enable read-only mode (`true` or `1`) | `false` |
+| `MEDIA_ALLOWED_TYPES` | Extra MIME types to allow for file path imports (comma-separated, e.g., `application/pdf`) | - |
+| `MEDIA_IMPORT_DIR` | Restrict file path imports to this directory | - |
+| `MEDIA_ALLOWED_HOSTS` | Allow specific private network hosts for URL imports (comma-separated, e.g., `192.168.1.50,my-nas`) | - |
 
 ## Usage Examples
 
@@ -420,6 +423,20 @@ The `findNotes` tool supports Anki's powerful query syntax:
 
 #### Deletion Safety
 The `deleteNotes` tool requires explicit confirmation (`confirmDeletion: true`) to prevent accidental deletions. Deleting a note removes ALL associated cards permanently.
+
+## Security
+
+### Media File Path and URL Validation
+
+The `mediaActions` tool and `updateNoteFields` audio/picture fields include security validation to prevent misuse via prompt injection:
+
+- **File path imports** are restricted to media file types only (images, audio, video). Non-media files (e.g., SSH keys, credentials, shell configs) are rejected based on MIME type. Configure `MEDIA_ALLOWED_TYPES` to allow additional file types, or `MEDIA_IMPORT_DIR` to restrict imports to a specific directory.
+- **URL imports** are validated against SSRF attacks. Requests to private networks (10.x, 172.16.x, 192.168.x), loopback (127.x), link-local (169.254.x), and non-HTTP(S) schemes are blocked. Configure `MEDIA_ALLOWED_HOSTS` to allow specific private network hosts.
+- **Filenames** are sanitized to prevent path traversal (e.g., `../../` sequences are stripped).
+
+These protections apply to `storeMediaFile`, `retrieveMediaFile`, `deleteMediaFile`, and `updateNoteFields` audio/picture fields.
+
+> Path traversal vulnerability reported by [Hideaki Takahashi](https://github.com/Koukyosyumei).
 
 ## Known Issues
 

--- a/docs/security/2026-04-08-media-path-traversal-analysis.md
+++ b/docs/security/2026-04-08-media-path-traversal-analysis.md
@@ -1,0 +1,181 @@
+# Analysis: mediaActions Path Traversal Report
+
+**Date:** 2026-04-08
+**Related report:** [2026-04-08-media-path-traversal-report.md](./2026-04-08-media-path-traversal-report.md)
+
+---
+
+## Verdict: Valid finding, medium severity (not high)
+
+The technical finding is correct. The `path` parameter in `storeMediaFile` is unsanitized and passed directly to AnkiConnect, which reads the file with the local user's permissions. Combined with `retrieveMediaFile`, this enables reading arbitrary files as base64.
+
+## Code path confirmed
+
+```
+mediaActions.tool.ts:64-65  →  path accepted as unconstrained string in Zod schema
+storeMediaFile.action.ts:72-73  →  path forwarded directly to AnkiConnect
+retrieveMediaFile.action.ts:38  →  returns file contents as base64
+```
+
+Additionally, the `url` parameter (line 74-75) has a similar lack of validation — potential SSRF vector (e.g., cloud metadata endpoints like `http://169.254.169.254/`). The reporter did not mention this.
+
+## Why medium, not high
+
+The full exploit chain requires all of these to succeed:
+
+1. **Prompt injection** — The LLM must be manipulated into calling `storeMediaFile` with a malicious path (e.g., via adversarial text in an Anki card). Non-trivial but possible.
+
+2. **Bypassing human-in-the-loop** — MCP clients like Claude Desktop display tool call parameters to the user before execution. The `path: "/home/user/.ssh/id_rsa"` would be visible. The tool is marked `destructiveHint: true`, which typically triggers confirmation prompts. Some clients may auto-approve, but most standard clients do not for destructive operations.
+
+3. **Exfiltration** — Even if the LLM retrieves base64 data, it appears in the user's conversation, not the attacker's. The attacker needs a separate channel to receive it. AnkiConnect's `storeMediaFile` URL fetch does GET only, so it can't POST data out.
+
+4. **`--read-only` mode blocks it** — `storeMediaFile` is in the `WRITE_ACTIONS` set (`anki-connect.client.ts:28`), so read-only deployments are unaffected.
+
+## PoC critique
+
+The reporter's PoC uses direct `client.call_tool()` calls — this demonstrates direct API access, not prompt injection. If an attacker controls the MCP client directly, they can already do anything (delete all notes, call any tool). The meaningful threat model is prompt injection through untrusted content, which is harder to execute reliably.
+
+## Assessment of proposed fixes
+
+### Option A: Remove `path` parameter — Rejected
+
+The README recommends file paths as best practice:
+> **Use file paths** (e.g., `/Users/you/image.png`) - Fast and efficient
+> **Avoid base64** - Extremely slow and token-inefficient
+
+Removing `path` forces all local files through base64 (massive token overhead and slow) or URL (requires files to be web-accessible). This is a significant UX regression for the primary use case (user asks LLM to add a local image to a flashcard).
+
+### Option B: Allowlist directory — Accepted as opt-in
+
+A strict mandatory allowlist is too restrictive for most users. A user saying "add this image from my Desktop to my flashcard" shouldn't need to pre-configure an env var. But it's a good opt-in hardening layer via `MEDIA_IMPORT_DIR` for security-conscious deployments.
+
+## Independent reviews
+
+Two independent agent reviews were conducted (TypeScript specialist + Security auditor). Key findings beyond the original report:
+
+### Additional findings (from security auditor)
+
+1. **SSRF via `updateNoteFields` audio/picture `url` fields** (CWE-918, Medium) — Same unsanitized URL pass-through, different tool. Marked `destructiveHint: false`, so clients may auto-approve more readily.
+2. **Filename path traversal (output direction)** (CWE-22, Low) — `filename` param in `storeMediaFile` is unsanitized. Could potentially write outside `collection.media/` if AnkiConnect doesn't sanitize. Depends on downstream behavior.
+3. **Pattern injection in `getMediaFilesNames`** (CWE-155, Informational) — `pattern` forwarded to AnkiConnect's glob. Low practical impact.
+4. **Suggestion: default `--read-only` when `--ngrok` is used** — Worth considering for highest-risk deployment mode.
+
+### Key insight from both reviewers
+
+Both independently rejected the denylist-as-primary approach (our initial recommendation). **Denylists are fundamentally incomplete** — you cannot enumerate all sensitive files across all OSes. Instead, both proposed a **file extension allowlist** as the primary defense: only allow paths ending in media extensions (`.jpg`, `.mp3`, `.png`, `.wav`, etc.). This is strictly better because:
+- It's an allowlist (complete by definition)
+- Sensitive files never have media extensions
+- Zero UX impact on legitimate use
+
+## Decision: Chosen approach
+
+### Layer 1: MIME type allowlist (always on, primary defense)
+
+Use `mime` v4 library to resolve the file extension to a MIME type. By default, only allow:
+- `image/*`
+- `audio/*`
+- `video/*`
+
+Everything else is rejected. Files with no recognized extension (e.g., `id_rsa`, `credentials`) return `null` from `mime` and are blocked.
+
+### Layer 2: User-defined extra types via `MEDIA_ALLOWED_TYPES` (opt-in)
+
+If a user needs to allow non-media files (e.g., PDFs, APKG archives), they can set:
+```
+MEDIA_ALLOWED_TYPES=application/pdf,application/apkg
+```
+These are added on top of the default media allowlist. Without this env var, only media MIME types pass.
+
+### Layer 3: Directory restriction via `MEDIA_IMPORT_DIR` (opt-in)
+
+If set, the resolved path must also be inside the configured directory:
+```
+MEDIA_IMPORT_DIR=/Users/me/anki-media
+```
+Without this env var, any directory is allowed (as long as Layer 1/2 passes).
+
+### Error handling
+
+Validation errors should help the user understand what went wrong and how to fix it, without revealing specifics that help an attacker probe the security rules (e.g., don't echo back the resolved path or the detected MIME type).
+
+Examples:
+- MIME check fail: `"File type not allowed. Only media files (images, audio, video) are accepted. To allow additional file types, set the MEDIA_ALLOWED_TYPES environment variable."`
+- Directory check fail: `"File path is outside the allowed import directory (/Users/me/anki-media). Update MEDIA_IMPORT_DIR to change the allowed directory."` (include the configured dir — the user set it themselves)
+
+Details like the resolved path and detected MIME type go to **server logs only** (warn-level), not in the error response.
+
+### Layer 4: URL/SSRF validation (always on)
+
+Using `ipaddr.js` to validate URLs passed to `storeMediaFile` and `updateNoteFields` audio/picture fields. By default, block:
+- Non-HTTP(S) schemes (`file://`, `ftp://`, `gopher://`, etc.)
+- Private IP ranges (10.x, 172.16-31.x, 192.168.x)
+- Loopback (127.x)
+- Link-local / cloud metadata (169.254.x)
+- Reserved/unspecified ranges
+
+### Layer 5: User-defined allowed IPs via `MEDIA_ALLOWED_HOSTS` (opt-in)
+
+If a user legitimately needs to fetch media from a private network (e.g., a NAS or local server), they can explicitly allow it:
+```
+MEDIA_ALLOWED_HOSTS=192.168.1.50,10.0.0.5
+```
+These hosts bypass the private IP check. Without this env var, all private/reserved IPs are blocked.
+
+Error example: `"URL blocked: requests to private/internal networks are not allowed. To allow specific hosts, set the MEDIA_ALLOWED_HOSTS environment variable."`
+
+### Also needed
+
+- Filename sanitization (strip `../`, path separators, limit to basename)
+- Update `path` schema description to explicitly say "media file"
+- Warn-level logging on every `path`/`url` usage (server-side only, not returned to LLM)
+
+## Severity summary table
+
+| # | Finding | CWE | Severity | Read-Only Blocks? |
+|---|---------|-----|----------|-------------------|
+| 1 | Arbitrary file read via `path` param | CWE-22, CWE-552 | Medium | Yes |
+| 2 | SSRF via `storeMediaFile` `url` param | CWE-918 | Medium | Yes |
+| 3 | SSRF via `updateNoteFields` audio/picture `url` | CWE-918 | Medium | Yes |
+| 4 | Filename path traversal (output direction) | CWE-22 | Low | Partially |
+| 5 | Pattern injection in `getMediaFilesNames` | CWE-155 | Informational | No |
+
+## Affected files for fix
+
+- `src/mcp/primitives/essential/tools/mediaActions/actions/storeMediaFile.action.ts` — Add path + URL validation
+- `src/mcp/primitives/essential/tools/mediaActions/mediaActions.tool.ts` — Update schema descriptions
+- `src/mcp/primitives/essential/tools/update-note-fields.tool.ts` — URL validation for audio/picture URLs
+- New: validation utility (file type validation, URL/SSRF checks)
+- Tests for validators
+
+## Library research (2026-04-08)
+
+### Path validation: `mime` v4
+
+**Chosen:** [`mime`](https://www.npmjs.com/package/mime) v4 — 104M downloads/week, zero dependencies, bundled TypeScript types, MIT license, ESM-only.
+
+Usage: `mime.getType(filePath)` returns MIME type string or `null`. Check result starts with `image/`, `audio/`, or `video/` to allow only media files.
+
+**Rejected alternatives:**
+- `mime-types` — works but CJS-only, no bundled types, less modern
+- `file-type` — wrong tool; detects type by reading file magic bytes, but we need to validate *before* reading the file
+
+**Note:** `mime` is ESM-only since v4. Project already handles ESM deps via `transformIgnorePatterns` in Jest config (ky, unified, remark-parse). Add `mime` to that pattern.
+
+### SSRF prevention: `ipaddr.js`
+
+**Chosen:** [`ipaddr.js`](https://www.npmjs.com/package/ipaddr.js) v2 — 80M downloads/week, zero dependencies, bundled TypeScript types, MIT license, CJS.
+
+No good drop-in SSRF library exists for ky/native fetch. All agent-based libraries (`request-filtering-agent`, `ssrf-req-filter`, `got-ssrf`) are incompatible. Build ~30-40 lines on top of `ipaddr.js` following the OWASP SSRF prevention guide for Node.js:
+
+1. Parse URL with `new URL(input)` — validates scheme and structure
+2. Check `url.protocol` is `http:` or `https:` — blocks `file://`, `ftp://`, `gopher://`
+3. Resolve hostname with `dns.promises.lookup()`
+4. Parse resolved IP with `ipaddr.parse()`
+5. Check `addr.range()` against blocked ranges: `'private'`, `'loopback'`, `'linkLocal'`, `'reserved'`, `'unspecified'`
+
+**Rejected alternatives:**
+- `request-filtering-agent` — agent-based, incompatible with ky/native fetch
+- `ssrf-req-filter` — same issue + unmaintained + no TypeScript types
+- `got-ssrf` — locked to `got` peer dependency
+- `dssrf` — 5 GitHub stars, misleading docs (claims zero deps, ships `got`), too new
+- `private-ip` — **has active CVE-2025-8020** (multicast range bypass), do not use

--- a/docs/security/2026-04-08-media-path-traversal-report.md
+++ b/docs/security/2026-04-08-media-path-traversal-report.md
@@ -1,0 +1,84 @@
+# Security Report: mediaActions Path Traversal
+
+**Reported by:** Hideaki Takahashi, Ph.D. student, Columbia University
+**Date received:** 2026-04-08
+**Affected component:** `mediaActions` tool — `storeMediaFile` action
+
+---
+
+## Original Report
+
+Dear Mr. Anatoly Tarnavsky,
+
+I hope this email finds you well. I am Hideaki Takahasih, a Ph.D. student working on software security at Columbia University, and I am responsibly disclosing a high-severity security vulnerability in the `mediaActions` MCP tool.
+
+Currently, the `storeMediaFile` action accepts a `path` parameter (`mediaActions.tool.ts:65`) which is passed directly to the underlying AnkiConnect API without any sanitization or validation. Because AnkiConnect runs with the permissions of the local user, supplying an absolute path to this endpoint allows the tool to read any file on the host machine and copy it into Anki's `collection.media` folder.
+
+```
+// storeMediaFile.action.ts:41-78
+export async function storeMediaFile(params, client) {
+  const { filename, data, path, url, deleteExisting = true } = params;
+  // ...
+  const ankiParams: Record<string, any> = { filename, deleteExisting };
+  if (data) ankiParams.data = data;
+  else if (path) ankiParams.path = path;  // no validation
+  else if (url)  ankiParams.url = url;
+  const result = await client.invoke<string>("storeMediaFile", ankiParams);
+```
+
+This creates a severe exploit chain when combined with the `retrieveMediaFile` action. An attacker, or a hijacked LLM agent via Prompt Injection, can store a sensitive local file into the Anki media collection, and then immediately retrieve its contents as a base64-encoded string.
+
+This flaw allows an untrusted MCP client or a manipulated LLM to exfiltrate any file readable by the OS user running Anki. This includes, but is not limited to:
+
+- SSH private keys (`~/.ssh/id_rsa`, `~/.ssh/id_ed25519`)
+- Environment variables and application secrets (`.env`, `~/.aws/credentials`)
+- Shell configurations and history (`~/.bashrc`, `~/.zsh_history`)
+
+As Proof of Concept, an attacker can execute the following sequence via the MCP client:
+
+```python
+# 1. Instruct the tool to read a sensitive local file and store it in Anki's media collection
+client.call_tool("mediaActions", {
+    "action": "storeMediaFile",
+    "path": "/home/user/.ssh/id_rsa", # Or %USERPROFILE%\.ssh\id_rsa on Windows
+    "filename": "exfiltrated_key",
+})
+
+# 2. Retrieve the copied file's content as a base64 string
+result = client.call_tool("mediaActions", {
+    "action": "retrieveMediaFile",
+    "filename": "exfiltrated_key",
+})
+
+# 3. Decode the result to view the private key
+import base64
+content = base64.b64decode(result["content"][0]["data"])
+print(content.decode())
+```
+
+The following codes are affected by this issue:
+
+- **`mediaActions.tool.ts`:** Exposes the `path` parameter as an unconstrained string in the schema.
+- **`storeMediaFile.action.ts`:** Forwards the `path` argument directly to `client.invoke<string>("storeMediaFile", ankiParams)` without path validation.
+
+Because MCP tools expose functionality to LLMs that frequently ingest untrusted text (making them vulnerable to prompt injection), unrestricted filesystem access should be avoided. I recommend one of the following two fixes:
+
+**Option A (Recommended): Remove the `path` parameter entirely**
+Remove `path` from the MCP tool schema. Force users and the LLM to upload media via the `data` (base64) or `url` parameters instead. The `path` option is a convenience meant for local scripts running within the same trust boundary as Anki, not for MCP exposure.
+
+**Option B: Implement a strict Server-Side Allowlist**
+If local file path reading is strictly necessary, gate it behind a configured allowlist directory.
+```typescript
+import * as nodepath from "path";
+const ALLOWED_IMPORT_ROOT = path.resolve(process.env.MEDIA_IMPORT_DIR || "");
+const resolved = path.resolve(params.path);
+
+if (!resolved.startsWith(ALLOWED_IMPORT_ROOT + path.sep)) {
+  throw new Error("Path must be within the configured media import directory.");
+}
+```
+
+Let me know if there is anything I can help.
+
+Sincerely,
+Hideaki

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,10 @@
         "@nestjs/platform-express": "^11.1.17",
         "@rekog/mcp-nest": "^1.9.8",
         "commander": "^14.0.3",
+        "ipaddr.js": "^2.3.0",
         "jsonwebtoken": "^9.0.3",
         "ky": "^1.14.3",
+        "mime": "^4.1.0",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "pino": "^10.3.1",
@@ -9639,12 +9641,12 @@
       }
     },
     "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
+      "integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10"
       }
     },
     "node_modules/is-arrayish": {
@@ -12635,16 +12637,18 @@
       }
     },
     "node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "dev": true,
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
+      "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
       "license": "MIT",
       "bin": {
-        "mime": "cli.js"
+        "mime": "bin/cli.js"
       },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/mime-db": {
@@ -13752,6 +13756,15 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
@@ -14977,6 +14990,19 @@
       },
       "engines": {
         "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/supertest": {

--- a/package.json
+++ b/package.json
@@ -60,8 +60,10 @@
     "@nestjs/platform-express": "^11.1.17",
     "@rekog/mcp-nest": "^1.9.8",
     "commander": "^14.0.3",
+    "ipaddr.js": "^2.3.0",
     "jsonwebtoken": "^9.0.3",
     "ky": "^1.14.3",
+    "mime": "^4.1.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pino": "^10.3.1",
@@ -148,7 +150,7 @@
       "^@test/(.*)$": "<rootDir>/test/$1"
     },
     "transformIgnorePatterns": [
-      "node_modules/(?!(ky|unified|remark-parse|unist-util-visit|mdast-util-to-string|micromark.*|decode-named-character-reference|character-entities|unist-.*|vfile.*|bail|is-plain-obj|trough|devlop|mdast.*|hast.*)/)"
+      "node_modules/(?!(ky|mime|unified|remark-parse|unist-util-visit|mdast-util-to-string|micromark.*|decode-named-character-reference|character-entities|unist-.*|vfile.*|bail|is-plain-obj|trough|devlop|mdast.*|hast.*)/)"
     ],
     "forceExit": true
   },

--- a/src/mcp/primitives/essential/tools/__tests__/update-note-fields.tool.spec.ts
+++ b/src/mcp/primitives/essential/tools/__tests__/update-note-fields.tool.spec.ts
@@ -9,8 +9,25 @@ import {
   parseToolResult,
   createMockContext,
 } from "../../../../../test-fixtures/test-helpers";
+import * as dns from "node:dns";
 
 jest.mock("../../../../clients/anki-connect.client");
+
+// Mock dns.promises.lookup for URL validation tests
+jest.mock("node:dns", () => {
+  const actual = jest.requireActual("node:dns");
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      lookup: jest.fn(),
+    },
+  };
+});
+
+const mockLookup = dns.promises.lookup as jest.MockedFunction<
+  typeof dns.promises.lookup
+>;
 
 describe("UpdateNoteFieldsTool", () => {
   let tool: UpdateNoteFieldsTool;
@@ -30,6 +47,12 @@ describe("UpdateNoteFieldsTool", () => {
     mockContext = createMockContext();
 
     jest.clearAllMocks();
+
+    // Default: resolve to a public IP so non-security tests aren't affected
+    mockLookup.mockResolvedValue({
+      address: "93.184.216.34",
+      family: 4,
+    } as any);
   });
 
   describe("updateNoteFields", () => {
@@ -37,7 +60,7 @@ describe("UpdateNoteFieldsTool", () => {
       // Arrange
       const noteId = mockNotes.spanish.noteId;
       const updatedFields = {
-        Front: "¿Qué tal?",
+        Front: "Que tal?",
         Back: "How are you doing?",
       };
 
@@ -390,6 +413,317 @@ describe("UpdateNoteFieldsTool", () => {
 
       // Assert
       expect(result.modelName).toBe("Basic (and reversed card)");
+    });
+  });
+
+  // ── Security guards ────────────────────────────────────────────────────────
+  // These tests verify that validateMediaUrl from media-validation.utils
+  // is actually called for audio and picture URL fields during note updates.
+
+  describe("security guards", () => {
+    describe("audio URL validation", () => {
+      it("should reject file:// URLs in audio[].url", async () => {
+        const rawResult = await tool.updateNoteFields(
+          {
+            note: {
+              id: mockNotes.spanish.noteId,
+              fields: { Front: "Test" },
+              audio: [
+                {
+                  url: "file:///etc/passwd",
+                  filename: "evil.mp3",
+                  fields: ["Front"],
+                },
+              ],
+            },
+          },
+          mockContext,
+        );
+        const result = parseToolResult(rawResult);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('URL scheme "file" is not allowed');
+        // Should fail before reaching AnkiConnect
+        expect(ankiClient.invoke).not.toHaveBeenCalled();
+      });
+
+      it("should reject private IP URLs in audio[].url", async () => {
+        mockLookup.mockResolvedValueOnce({
+          address: "192.168.1.50",
+          family: 4,
+        } as any);
+
+        const rawResult = await tool.updateNoteFields(
+          {
+            note: {
+              id: mockNotes.spanish.noteId,
+              fields: { Front: "Test" },
+              audio: [
+                {
+                  url: "https://internal.corp/secret.mp3",
+                  filename: "audio.mp3",
+                  fields: ["Front"],
+                },
+              ],
+            },
+          },
+          mockContext,
+        );
+        const result = parseToolResult(rawResult);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain(
+          "requests to private/internal networks are not allowed",
+        );
+        expect(ankiClient.invoke).not.toHaveBeenCalled();
+      });
+
+      it("should allow public URLs in audio[].url", async () => {
+        mockLookup.mockResolvedValueOnce({
+          address: "93.184.216.34",
+          family: 4,
+        } as any);
+
+        ankiClient.invoke
+          .mockResolvedValueOnce([mockNotes.spanish]) // notesInfo
+          .mockResolvedValueOnce(null); // updateNoteFields
+
+        const rawResult = await tool.updateNoteFields(
+          {
+            note: {
+              id: mockNotes.spanish.noteId,
+              fields: { Front: "Test" },
+              audio: [
+                {
+                  url: "https://cdn.example.com/pronunciation.mp3",
+                  filename: "pronunciation.mp3",
+                  fields: ["Front"],
+                },
+              ],
+            },
+          },
+          mockContext,
+        );
+        const result = parseToolResult(rawResult);
+
+        expect(result.success).toBe(true);
+        expect(ankiClient.invoke).toHaveBeenCalledTimes(2);
+      });
+
+      it("rejects if any audio URL in array is malicious", async () => {
+        // First lookup returns public IP, second returns private
+        mockLookup
+          .mockResolvedValueOnce({ address: "93.184.216.34", family: 4 })
+          .mockResolvedValueOnce({ address: "192.168.1.1", family: 4 });
+
+        const result = await tool.updateNoteFields(
+          {
+            note: {
+              id: 1234567890,
+              fields: { Front: "test" },
+              audio: [
+                {
+                  url: "https://safe.com/audio1.mp3",
+                  filename: "safe.mp3",
+                  fields: ["Front"],
+                },
+                {
+                  url: "http://evil.internal/steal.mp3",
+                  filename: "evil.mp3",
+                  fields: ["Back"],
+                },
+              ],
+            },
+          },
+          mockContext,
+        );
+
+        expect(result).toHaveProperty("isError", true);
+        expect(ankiClient.invoke).not.toHaveBeenCalledWith(
+          "updateNoteFields",
+          expect.anything(),
+        );
+      });
+    });
+
+    describe("picture URL validation", () => {
+      it("should reject file:// URLs in picture[].url", async () => {
+        const rawResult = await tool.updateNoteFields(
+          {
+            note: {
+              id: mockNotes.spanish.noteId,
+              fields: { Front: "Test" },
+              picture: [
+                {
+                  url: "file:///etc/shadow",
+                  filename: "evil.jpg",
+                  fields: ["Back"],
+                },
+              ],
+            },
+          },
+          mockContext,
+        );
+        const result = parseToolResult(rawResult);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('URL scheme "file" is not allowed');
+        expect(ankiClient.invoke).not.toHaveBeenCalled();
+      });
+
+      it("should reject private IP URLs in picture[].url", async () => {
+        mockLookup.mockResolvedValueOnce({
+          address: "10.0.0.1",
+          family: 4,
+        } as any);
+
+        const rawResult = await tool.updateNoteFields(
+          {
+            note: {
+              id: mockNotes.spanish.noteId,
+              fields: { Front: "Test" },
+              picture: [
+                {
+                  url: "https://admin-panel.internal/logo.png",
+                  filename: "image.jpg",
+                  fields: ["Back"],
+                },
+              ],
+            },
+          },
+          mockContext,
+        );
+        const result = parseToolResult(rawResult);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain(
+          "requests to private/internal networks are not allowed",
+        );
+        expect(ankiClient.invoke).not.toHaveBeenCalled();
+      });
+
+      it("should allow public URLs in picture[].url", async () => {
+        mockLookup.mockResolvedValueOnce({
+          address: "151.101.1.67",
+          family: 4,
+        } as any);
+
+        ankiClient.invoke
+          .mockResolvedValueOnce([mockNotes.spanish]) // notesInfo
+          .mockResolvedValueOnce(null); // updateNoteFields
+
+        const rawResult = await tool.updateNoteFields(
+          {
+            note: {
+              id: mockNotes.spanish.noteId,
+              fields: { Front: "Test" },
+              picture: [
+                {
+                  url: "https://images.example.com/photo.jpg",
+                  filename: "photo.jpg",
+                  fields: ["Back"],
+                },
+              ],
+            },
+          },
+          mockContext,
+        );
+        const result = parseToolResult(rawResult);
+
+        expect(result.success).toBe(true);
+        expect(ankiClient.invoke).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe("mixed media URL validation", () => {
+      it("validates both audio and picture URLs in same request", async () => {
+        // Audio URL is fine, picture URL resolves to private IP
+        mockLookup
+          .mockResolvedValueOnce({ address: "93.184.216.34", family: 4 })
+          .mockResolvedValueOnce({ address: "10.0.0.1", family: 4 });
+
+        const result = await tool.updateNoteFields(
+          {
+            note: {
+              id: 1234567890,
+              fields: { Front: "test" },
+              audio: [
+                {
+                  url: "https://safe.com/audio.mp3",
+                  filename: "audio.mp3",
+                  fields: ["Front"],
+                },
+              ],
+              picture: [
+                {
+                  url: "http://internal-server/secret.png",
+                  filename: "secret.png",
+                  fields: ["Back"],
+                },
+              ],
+            },
+          },
+          mockContext,
+        );
+
+        expect(result).toHaveProperty("isError", true);
+        expect(ankiClient.invoke).not.toHaveBeenCalledWith(
+          "updateNoteFields",
+          expect.anything(),
+        );
+      });
+    });
+
+    describe("media filename sanitization", () => {
+      it("sanitizes audio filename path traversal", async () => {
+        mockLookup.mockResolvedValue({
+          address: "93.184.216.34",
+          family: 4,
+        } as any);
+
+        // Mock the notesInfo call that happens before updateNoteFields
+        ankiClient.invoke.mockImplementation(async (action: string) => {
+          if (action === "notesInfo") {
+            return [
+              {
+                noteId: 1234567890,
+                modelName: "Basic",
+                fields: {
+                  Front: { value: "test" },
+                  Back: { value: "answer" },
+                },
+                tags: [],
+              },
+            ];
+          }
+          return null;
+        });
+
+        await tool.updateNoteFields(
+          {
+            note: {
+              id: 1234567890,
+              fields: { Front: "test" },
+              audio: [
+                {
+                  url: "https://safe.com/audio.mp3",
+                  filename: "../../evil.mp3",
+                  fields: ["Front"],
+                },
+              ],
+            },
+          },
+          mockContext,
+        );
+
+        // Verify the filename was sanitized in the AnkiConnect call
+        const updateCall = ankiClient.invoke.mock.calls.find(
+          (call: any[]) => call[0] === "updateNoteFields",
+        );
+        if (updateCall) {
+          expect(updateCall[1].note.audio[0].filename).toBe("evil.mp3");
+        }
+      });
     });
   });
 });

--- a/src/mcp/primitives/essential/tools/collection-stats/collection-stats.tool.ts
+++ b/src/mcp/primitives/essential/tools/collection-stats/collection-stats.tool.ts
@@ -30,7 +30,8 @@ export class CollectionStatsTool {
       "Ease buckets and interval buckets can be customized to focus on specific ranges.",
     parameters: z.object({
       ease_buckets: z
-        .array(z.number().positive()).max(20)
+        .array(z.number().positive())
+        .max(20)
         .optional()
         .default([2.0, 2.5, 3.0])
         .refine(
@@ -45,7 +46,8 @@ export class CollectionStatsTool {
             "Example: [2.0, 2.5, 3.0] creates buckets: <2.0, 2.0-2.5, 2.5-3.0, >3.0",
         ),
       interval_buckets: z
-        .array(z.number().positive()).max(20)
+        .array(z.number().positive())
+        .max(20)
         .optional()
         .default([7, 21, 90])
         .refine(

--- a/src/mcp/primitives/essential/tools/deckActions/deckActions.tool.ts
+++ b/src/mcp/primitives/essential/tools/deckActions/deckActions.tool.ts
@@ -52,13 +52,15 @@ Remember to sync first at the start of a session for latest data.`,
           '[deckStats/changeDeck] Deck name (e.g., "Japanese::JLPT N5")',
         ),
       easeBuckets: z
-        .array(z.number().positive()).max(20)
+        .array(z.number().positive())
+        .max(20)
         .optional()
         .describe(
           "[deckStats] Bucket boundaries for ease factor distribution. Default: [2.0, 2.5, 3.0]",
         ),
       intervalBuckets: z
-        .array(z.number().positive()).max(20)
+        .array(z.number().positive())
+        .max(20)
         .optional()
         .describe(
           "[deckStats] Bucket boundaries for interval distribution in days. Default: [7, 21, 90]",

--- a/src/mcp/primitives/essential/tools/mediaActions/__tests__/mediaActions.tool.spec.ts
+++ b/src/mcp/primitives/essential/tools/mediaActions/__tests__/mediaActions.tool.spec.ts
@@ -5,9 +5,26 @@ import {
   parseToolResult,
   createMockContext,
 } from "@/test-fixtures/test-helpers";
+import * as dns from "node:dns";
 
 // Mock the AnkiConnectClient
 jest.mock("@/mcp/clients/anki-connect.client");
+
+// Mock dns.promises.lookup for URL validation tests
+jest.mock("node:dns", () => {
+  const actual = jest.requireActual("node:dns");
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      lookup: jest.fn(),
+    },
+  };
+});
+
+const mockLookup = dns.promises.lookup as jest.MockedFunction<
+  typeof dns.promises.lookup
+>;
 
 describe("MediaActionsTool", () => {
   let tool: MediaActionsTool;
@@ -27,8 +44,20 @@ describe("MediaActionsTool", () => {
     // Setup mock context
     mockContext = createMockContext();
 
+    // Default: resolve to a public IP so existing URL tests pass
+    mockLookup.mockResolvedValue({
+      address: "93.184.216.34",
+      family: 4,
+    } as any);
+
     // Clear all mocks before each test
     jest.clearAllMocks();
+
+    // Re-apply default after clearAllMocks
+    mockLookup.mockResolvedValue({
+      address: "93.184.216.34",
+      family: 4,
+    } as any);
   });
 
   describe("storeMediaFile action", () => {
@@ -328,6 +357,352 @@ describe("MediaActionsTool", () => {
       expect(mockContext.reportProgress).toHaveBeenCalledWith({
         progress: 100,
         total: 100,
+      });
+    });
+  });
+
+  // ── Security guards ────────────────────────────────────────────────────────
+  // These tests verify that the validation utilities from media-validation.utils
+  // are actually wired into the tool execution paths, not just tested in isolation.
+
+  describe("security guards", () => {
+    describe("storeMediaFile path validation", () => {
+      it("should reject non-media file paths (e.g., .ssh/id_rsa)", async () => {
+        const params = {
+          action: "storeMediaFile" as const,
+          filename: "stolen.txt",
+          path: "/home/user/.ssh/id_rsa",
+        };
+
+        const rawResult = await tool.execute(params, mockContext);
+        const result = parseToolResult(rawResult);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("Only media files");
+        expect(ankiClient.invoke).not.toHaveBeenCalled();
+      });
+
+      it("should reject .env files", async () => {
+        const params = {
+          action: "storeMediaFile" as const,
+          filename: "secrets.txt",
+          path: "/home/user/.env",
+        };
+
+        const rawResult = await tool.execute(params, mockContext);
+        const result = parseToolResult(rawResult);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("Only media files");
+        expect(ankiClient.invoke).not.toHaveBeenCalled();
+      });
+
+      it("should allow media file paths (e.g., /photos/cat.jpg)", async () => {
+        const params = {
+          action: "storeMediaFile" as const,
+          filename: "cat.jpg",
+          path: "/photos/cat.jpg",
+        };
+        ankiClient.invoke.mockResolvedValueOnce("cat.jpg");
+
+        const rawResult = await tool.execute(params, mockContext);
+        const result = parseToolResult(rawResult);
+
+        expect(result.success).toBe(true);
+        expect(ankiClient.invoke).toHaveBeenCalledWith(
+          "storeMediaFile",
+          expect.objectContaining({ path: "/photos/cat.jpg" }),
+        );
+      });
+
+      it("should respect MEDIA_ALLOWED_TYPES env var", async () => {
+        const originalEnv = process.env.MEDIA_ALLOWED_TYPES;
+        try {
+          // PDF is not allowed by default
+          const params = {
+            action: "storeMediaFile" as const,
+            filename: "doc.pdf",
+            path: "/docs/manual.pdf",
+          };
+
+          // First: without env var, PDF should be rejected
+          const rawResultBlocked = await tool.execute(params, mockContext);
+          const resultBlocked = parseToolResult(rawResultBlocked);
+          expect(resultBlocked.success).toBe(false);
+          expect(resultBlocked.error).toContain("Only media files");
+
+          // Now allow PDF via env var
+          process.env.MEDIA_ALLOWED_TYPES = "application/pdf";
+          ankiClient.invoke.mockResolvedValueOnce("doc.pdf");
+
+          const rawResultAllowed = await tool.execute(params, mockContext);
+          const resultAllowed = parseToolResult(rawResultAllowed);
+          expect(resultAllowed.success).toBe(true);
+          expect(ankiClient.invoke).toHaveBeenCalled();
+        } finally {
+          if (originalEnv === undefined) {
+            delete process.env.MEDIA_ALLOWED_TYPES;
+          } else {
+            process.env.MEDIA_ALLOWED_TYPES = originalEnv;
+          }
+        }
+      });
+
+      it("should respect MEDIA_IMPORT_DIR env var", async () => {
+        const originalEnv = process.env.MEDIA_IMPORT_DIR;
+        try {
+          process.env.MEDIA_IMPORT_DIR = "/allowed/media";
+
+          // A file outside the allowed directory should be rejected
+          const params = {
+            action: "storeMediaFile" as const,
+            filename: "cat.jpg",
+            path: "/other/directory/cat.jpg",
+          };
+
+          const rawResult = await tool.execute(params, mockContext);
+          const result = parseToolResult(rawResult);
+
+          expect(result.success).toBe(false);
+          expect(result.error).toContain(
+            "outside the allowed import directory",
+          );
+          expect(ankiClient.invoke).not.toHaveBeenCalled();
+        } finally {
+          if (originalEnv === undefined) {
+            delete process.env.MEDIA_IMPORT_DIR;
+          } else {
+            process.env.MEDIA_IMPORT_DIR = originalEnv;
+          }
+        }
+      });
+    });
+
+    describe("storeMediaFile URL validation", () => {
+      it("should reject file:// URLs", async () => {
+        const params = {
+          action: "storeMediaFile" as const,
+          filename: "stolen.mp3",
+          url: "file:///etc/passwd",
+        };
+
+        const rawResult = await tool.execute(params, mockContext);
+        const result = parseToolResult(rawResult);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('URL scheme "file" is not allowed');
+        expect(ankiClient.invoke).not.toHaveBeenCalled();
+      });
+
+      it("should reject URLs resolving to private IPs", async () => {
+        mockLookup.mockResolvedValueOnce({
+          address: "192.168.1.100",
+          family: 4,
+        } as any);
+
+        const params = {
+          action: "storeMediaFile" as const,
+          filename: "internal.mp3",
+          url: "https://internal-server.local/audio.mp3",
+        };
+
+        const rawResult = await tool.execute(params, mockContext);
+        const result = parseToolResult(rawResult);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain(
+          "requests to private/internal networks are not allowed",
+        );
+        expect(ankiClient.invoke).not.toHaveBeenCalled();
+      });
+
+      it("should allow URLs resolving to public IPs", async () => {
+        mockLookup.mockResolvedValueOnce({
+          address: "93.184.216.34",
+          family: 4,
+        } as any);
+
+        const params = {
+          action: "storeMediaFile" as const,
+          filename: "public.mp3",
+          url: "https://cdn.example.com/audio.mp3",
+        };
+        ankiClient.invoke.mockResolvedValueOnce("public.mp3");
+
+        const rawResult = await tool.execute(params, mockContext);
+        const result = parseToolResult(rawResult);
+
+        expect(result.success).toBe(true);
+        expect(ankiClient.invoke).toHaveBeenCalledWith(
+          "storeMediaFile",
+          expect.objectContaining({ url: "https://cdn.example.com/audio.mp3" }),
+        );
+      });
+
+      it("should respect MEDIA_ALLOWED_HOSTS env var", async () => {
+        const originalEnv = process.env.MEDIA_ALLOWED_HOSTS;
+        try {
+          // Resolve to a private IP — normally blocked
+          mockLookup.mockResolvedValue({
+            address: "192.168.1.100",
+            family: 4,
+          } as any);
+
+          const params = {
+            action: "storeMediaFile" as const,
+            filename: "internal.mp3",
+            url: "https://my-nas.local/audio.mp3",
+          };
+
+          // First: without MEDIA_ALLOWED_HOSTS, should be blocked
+          const rawResultBlocked = await tool.execute(params, mockContext);
+          const resultBlocked = parseToolResult(rawResultBlocked);
+          expect(resultBlocked.success).toBe(false);
+          expect(resultBlocked.error).toContain("private/internal networks");
+
+          // Now allow the host
+          process.env.MEDIA_ALLOWED_HOSTS = "my-nas.local";
+          ankiClient.invoke.mockResolvedValueOnce("internal.mp3");
+
+          const rawResultAllowed = await tool.execute(params, mockContext);
+          const resultAllowed = parseToolResult(rawResultAllowed);
+          expect(resultAllowed.success).toBe(true);
+        } finally {
+          if (originalEnv === undefined) {
+            delete process.env.MEDIA_ALLOWED_HOSTS;
+          } else {
+            process.env.MEDIA_ALLOWED_HOSTS = originalEnv;
+          }
+        }
+      });
+    });
+
+    describe("storeMediaFile filename sanitization", () => {
+      it("sanitizes path traversal in filename for storeMediaFile", async () => {
+        const tool = new MediaActionsTool(ankiClient as any);
+        ankiClient.invoke.mockResolvedValue("safe_name.jpg");
+
+        await tool.execute(
+          {
+            action: "storeMediaFile",
+            filename: "../../evil.jpg",
+            data: "base64data",
+          },
+          mockContext,
+        );
+
+        expect(ankiClient.invoke).toHaveBeenCalledWith(
+          "storeMediaFile",
+          expect.objectContaining({ filename: "evil.jpg" }),
+        );
+      });
+
+      it("sends resolved path to AnkiConnect, not original path", async () => {
+        const tool = new MediaActionsTool(ankiClient as any);
+        ankiClient.invoke.mockResolvedValue("image.jpg");
+
+        await tool.execute(
+          {
+            action: "storeMediaFile",
+            filename: "image.jpg",
+            path: "/photos/../photos/image.jpg",
+          },
+          mockContext,
+        );
+
+        // The resolved path should not contain ../
+        const invokeCall = ankiClient.invoke.mock.calls[0];
+        expect(invokeCall[1].path).not.toContain("..");
+      });
+    });
+
+    describe("storeMediaFile cloud metadata protection", () => {
+      it("blocks cloud metadata endpoint (169.254.169.254)", async () => {
+        mockLookup.mockResolvedValue({
+          address: "169.254.169.254",
+          family: 4,
+        } as any);
+        const tool = new MediaActionsTool(ankiClient as any);
+
+        const result = await tool.execute(
+          {
+            action: "storeMediaFile",
+            filename: "metadata.txt",
+            url: "http://169.254.169.254/latest/meta-data/",
+          },
+          mockContext,
+        );
+
+        expect(result).toHaveProperty("isError", true);
+        expect(ankiClient.invoke).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("retrieveMediaFile filename sanitization", () => {
+      it("should sanitize path traversal in filename", async () => {
+        const params = {
+          action: "retrieveMediaFile" as const,
+          filename: "../../.bashrc",
+        };
+        ankiClient.invoke.mockResolvedValueOnce("file-contents-base64");
+
+        const rawResult = await tool.execute(params, mockContext);
+        const result = parseToolResult(rawResult);
+
+        // The sanitized filename should have traversal sequences stripped
+        expect(ankiClient.invoke).toHaveBeenCalledWith("retrieveMediaFile", {
+          filename: ".bashrc",
+        });
+        expect(result.success).toBe(true);
+        expect(result.filename).toBe(".bashrc");
+      });
+
+      it("should pass normal filenames through unchanged", async () => {
+        const params = {
+          action: "retrieveMediaFile" as const,
+          filename: "pronunciation.mp3",
+        };
+        ankiClient.invoke.mockResolvedValueOnce("base64data");
+
+        await tool.execute(params, mockContext);
+
+        expect(ankiClient.invoke).toHaveBeenCalledWith("retrieveMediaFile", {
+          filename: "pronunciation.mp3",
+        });
+      });
+    });
+
+    describe("deleteMediaFile filename sanitization", () => {
+      it("should sanitize path traversal in filename", async () => {
+        const params = {
+          action: "deleteMediaFile" as const,
+          filename: "../../etc/passwd",
+        };
+        ankiClient.invoke.mockResolvedValueOnce(undefined);
+
+        const rawResult = await tool.execute(params, mockContext);
+        const result = parseToolResult(rawResult);
+
+        // Path traversal sequences and separators are stripped
+        expect(ankiClient.invoke).toHaveBeenCalledWith("deleteMediaFile", {
+          filename: "etcpasswd",
+        });
+        expect(result.success).toBe(true);
+        expect(result.filename).toBe("etcpasswd");
+      });
+
+      it("should pass normal filenames through unchanged", async () => {
+        const params = {
+          action: "deleteMediaFile" as const,
+          filename: "old_recording.mp3",
+        };
+        ankiClient.invoke.mockResolvedValueOnce(undefined);
+
+        await tool.execute(params, mockContext);
+
+        expect(ankiClient.invoke).toHaveBeenCalledWith("deleteMediaFile", {
+          filename: "old_recording.mp3",
+        });
       });
     });
   });

--- a/src/mcp/primitives/essential/tools/mediaActions/actions/deleteMediaFile.action.ts
+++ b/src/mcp/primitives/essential/tools/mediaActions/actions/deleteMediaFile.action.ts
@@ -1,4 +1,5 @@
 import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
+import { sanitizeMediaFilename } from "@/mcp/utils/media-validation.utils";
 
 /**
  * Parameters for deleteMediaFile action
@@ -24,12 +25,13 @@ export async function deleteMediaFile(
   params: DeleteMediaFileParams,
   client: AnkiConnectClient,
 ): Promise<DeleteMediaFileResult> {
-  const { filename } = params;
-
   // Validate filename
-  if (!filename || filename.trim() === "") {
+  if (!params.filename || params.filename.trim() === "") {
     throw new Error("Filename cannot be empty");
   }
+
+  // Sanitize filename to prevent path traversal
+  const filename = sanitizeMediaFilename(params.filename);
 
   // Call AnkiConnect
   await client.invoke<void>("deleteMediaFile", {

--- a/src/mcp/primitives/essential/tools/mediaActions/actions/retrieveMediaFile.action.ts
+++ b/src/mcp/primitives/essential/tools/mediaActions/actions/retrieveMediaFile.action.ts
@@ -1,4 +1,5 @@
 import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
+import { sanitizeMediaFilename } from "@/mcp/utils/media-validation.utils";
 
 /**
  * Parameters for retrieveMediaFile action
@@ -27,12 +28,13 @@ export async function retrieveMediaFile(
   params: RetrieveMediaFileParams,
   client: AnkiConnectClient,
 ): Promise<RetrieveMediaFileResult> {
-  const { filename } = params;
-
   // Validate filename
-  if (!filename || filename.trim() === "") {
+  if (!params.filename || params.filename.trim() === "") {
     throw new Error("Filename cannot be empty");
   }
+
+  // Sanitize filename to prevent path traversal
+  const filename = sanitizeMediaFilename(params.filename);
 
   // Call AnkiConnect
   const result = await client.invoke<string | false>("retrieveMediaFile", {

--- a/src/mcp/primitives/essential/tools/mediaActions/actions/storeMediaFile.action.ts
+++ b/src/mcp/primitives/essential/tools/mediaActions/actions/storeMediaFile.action.ts
@@ -1,4 +1,14 @@
+import { Logger } from "@nestjs/common";
 import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
+import {
+  validateMediaFilePath,
+  validateMediaUrl,
+  sanitizeMediaFilename,
+  getMediaFilePathConfigFromEnv,
+  getMediaUrlConfigFromEnv,
+} from "@/mcp/utils/media-validation.utils";
+
+const logger = new Logger("storeMediaFile");
 
 /**
  * Parameters for storeMediaFile action
@@ -38,7 +48,7 @@ export async function storeMediaFile(
   params: StoreMediaFileParams,
   client: AnkiConnectClient,
 ): Promise<StoreMediaFileResult> {
-  const { filename, data, path, url, deleteExisting = true } = params;
+  const { data, path, url, deleteExisting = true } = params;
 
   // Validate that at least one source is provided
   if (!data && !path && !url) {
@@ -54,8 +64,36 @@ export async function storeMediaFile(
   }
 
   // Validate filename
-  if (!filename || filename.trim() === "") {
+  if (!params.filename || params.filename.trim() === "") {
     throw new Error("Filename cannot be empty");
+  }
+
+  // Sanitize filename to prevent path traversal in output
+  const filename = sanitizeMediaFilename(params.filename);
+
+  // Validate file path if provided (MIME type allowlist + optional directory restriction)
+  // Store the resolved path to send to AnkiConnect instead of the original unsanitized path
+  let validatedPath: string | undefined;
+  if (path) {
+    const { resolvedPath, mimeType } = validateMediaFilePath(
+      path,
+      getMediaFilePathConfigFromEnv(),
+    );
+    validatedPath = resolvedPath;
+    logger.warn(
+      `storeMediaFile path validation: resolved="${resolvedPath}", mime="${mimeType}"`,
+    );
+  }
+
+  // Validate URL if provided (SSRF prevention)
+  if (url) {
+    const { hostname, resolvedIp } = await validateMediaUrl(
+      url,
+      getMediaUrlConfigFromEnv(),
+    );
+    logger.warn(
+      `storeMediaFile URL validation: hostname="${hostname}", resolvedIp="${resolvedIp}"`,
+    );
   }
 
   // Check if filename starts with underscore (prevents Anki from removing unused media)
@@ -69,8 +107,8 @@ export async function storeMediaFile(
 
   if (data) {
     ankiParams.data = data;
-  } else if (path) {
-    ankiParams.path = path;
+  } else if (validatedPath) {
+    ankiParams.path = validatedPath;
   } else if (url) {
     ankiParams.url = url;
   }

--- a/src/mcp/primitives/essential/tools/mediaActions/mediaActions.tool.ts
+++ b/src/mcp/primitives/essential/tools/mediaActions/mediaActions.tool.ts
@@ -62,7 +62,9 @@ Perfect for workflows like ElevenLabs TTS → Anki audio flashcards.`,
       path: z
         .string()
         .optional()
-        .describe("[storeMediaFile only] Absolute file path"),
+        .describe(
+          "[storeMediaFile only] Absolute path to a local media file (images, audio, video only)",
+        ),
       url: z
         .string()
         .optional()

--- a/src/mcp/primitives/essential/tools/tagActions/tagActions.tool.ts
+++ b/src/mcp/primitives/essential/tools/tagActions/tagActions.tool.ts
@@ -42,7 +42,9 @@ Tags in addTags/removeTags are space-separated strings (e.g., "tag1 tag2 tag3").
         .enum(["addTags", "removeTags", "replaceTags", "clearUnusedTags"])
         .describe("The tag action to perform"),
       notes: z
-        .array(z.number()).min(1).max(1000)
+        .array(z.number())
+        .min(1)
+        .max(1000)
         .optional()
         .describe(
           "[addTags, removeTags, replaceTags] Array of note IDs to modify",

--- a/src/mcp/primitives/essential/tools/update-note-fields.tool.ts
+++ b/src/mcp/primitives/essential/tools/update-note-fields.tool.ts
@@ -4,6 +4,11 @@ import type { Context } from "@rekog/mcp-nest";
 import { z } from "zod";
 import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
 import { createErrorResponse } from "@/mcp/utils/anki.utils";
+import {
+  validateMediaUrl,
+  sanitizeMediaFilename,
+  getMediaUrlConfigFromEnv,
+} from "@/mcp/utils/media-validation.utils";
 
 /**
  * Tool for updating fields of existing notes
@@ -104,6 +109,36 @@ export class UpdateNoteFieldsTool {
           noteId: note.id,
           hint: "Provide at least one field to update",
         });
+      }
+
+      // Validate audio URLs for SSRF and sanitize filenames
+      if (note.audio) {
+        const urlConfig = getMediaUrlConfigFromEnv();
+        for (const audioItem of note.audio) {
+          const { hostname, resolvedIp } = await validateMediaUrl(
+            audioItem.url,
+            urlConfig,
+          );
+          this.logger.warn(
+            `updateNoteFields audio URL validation: hostname="${hostname}", resolvedIp="${resolvedIp}"`,
+          );
+          audioItem.filename = sanitizeMediaFilename(audioItem.filename);
+        }
+      }
+
+      // Validate picture URLs for SSRF and sanitize filenames
+      if (note.picture) {
+        const urlConfig = getMediaUrlConfigFromEnv();
+        for (const pictureItem of note.picture) {
+          const { hostname, resolvedIp } = await validateMediaUrl(
+            pictureItem.url,
+            urlConfig,
+          );
+          this.logger.warn(
+            `updateNoteFields picture URL validation: hostname="${hostname}", resolvedIp="${resolvedIp}"`,
+          );
+          pictureItem.filename = sanitizeMediaFilename(pictureItem.filename);
+        }
       }
 
       await context.reportProgress({ progress: 25, total: 100 });

--- a/src/mcp/utils/__tests__/media-validation.utils.spec.ts
+++ b/src/mcp/utils/__tests__/media-validation.utils.spec.ts
@@ -1,0 +1,608 @@
+/**
+ * Unit tests for media validation utilities
+ */
+
+import * as dns from "node:dns";
+import {
+  validateMediaFilePath,
+  validateMediaUrl,
+  sanitizeMediaFilename,
+  MediaFileTypeError,
+  MediaImportDirError,
+  MediaUrlBlockedError,
+  MediaUrlSchemeError,
+  MediaUrlInvalidError,
+  getMediaFilePathConfigFromEnv,
+  getMediaUrlConfigFromEnv,
+} from "../media-validation.utils";
+
+// ── Mock dns.promises.lookup ────────────────────────────────────────────────
+
+jest.mock("node:dns", () => {
+  const actual = jest.requireActual("node:dns");
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      lookup: jest.fn(),
+    },
+  };
+});
+
+const mockLookup = dns.promises.lookup as jest.MockedFunction<
+  typeof dns.promises.lookup
+>;
+
+// ── validateMediaFilePath ───────────────────────────────────────────────────
+
+describe("validateMediaFilePath", () => {
+  describe("allows common media extensions", () => {
+    const allowedFiles = [
+      "/photos/cat.jpg",
+      "/photos/cat.jpeg",
+      "/photos/diagram.png",
+      "/photos/icon.gif",
+      "/photos/photo.webp",
+      "/photos/vector.svg",
+      "/photos/raw.bmp",
+      "/photos/icon.ico",
+      "/audio/speech.mp3",
+      "/audio/sound.wav",
+      "/audio/track.ogg",
+      "/audio/music.flac",
+      "/audio/clip.m4a",
+      "/audio/voice.aac",
+      "/video/clip.mp4",
+      "/video/movie.webm",
+      "/video/recording.avi",
+      "/video/film.mkv",
+      "/video/clip.mov",
+    ];
+
+    it.each(allowedFiles)("allows %s", (filePath) => {
+      const result = validateMediaFilePath(filePath);
+      // Just verify it starts with one of the allowed prefixes
+      expect(
+        result.mimeType.startsWith("image/") ||
+          result.mimeType.startsWith("audio/") ||
+          result.mimeType.startsWith("video/"),
+      ).toBe(true);
+      expect(result.resolvedPath).toBeTruthy();
+    });
+  });
+
+  describe("blocks non-media files", () => {
+    const blockedFiles = [
+      "/home/user/.ssh/id_rsa",
+      "/home/user/.env",
+      "/etc/passwd",
+      "/home/user/credentials",
+      "/home/user/notes.txt",
+      "/home/user/config.json",
+      "/home/user/script.js",
+      "/home/user/data.csv",
+      "/home/user/archive.zip",
+      "/home/user/doc.pdf",
+      "/home/user/noextension",
+      "/home/user/.bashrc",
+      "/home/user/.gitconfig",
+    ];
+
+    it.each(blockedFiles)("blocks %s", (filePath) => {
+      expect(() => validateMediaFilePath(filePath)).toThrow(MediaFileTypeError);
+    });
+
+    it("blocks files with no extension", () => {
+      expect(() => validateMediaFilePath("/some/path/id_rsa")).toThrow(
+        MediaFileTypeError,
+      );
+    });
+
+    it("provides helpful error message", () => {
+      expect(() => validateMediaFilePath("/home/user/.env")).toThrow(
+        /Only media files \(images, audio, video\) are accepted/,
+      );
+    });
+
+    it("blocks .ts files (TypeScript, not MPEG transport stream) note: mime resolves .ts as video/mp2t", () => {
+      // .ts is technically a video MIME type (MPEG transport stream)
+      // so mime resolves it as video/mp2t and it passes the media check.
+      // This is acceptable — the MIME allowlist is about file type, not content.
+      // A real .ts TypeScript file named "app.ts" would pass the MIME check
+      // but that's an edge case since media tools wouldn't realistically be
+      // pointed at TypeScript files via prompt injection.
+      const result = validateMediaFilePath("/home/user/app.ts");
+      expect(result.mimeType).toBe("video/mp2t");
+    });
+  });
+
+  describe("null byte injection", () => {
+    it("blocks paths with null bytes", () => {
+      expect(() => validateMediaFilePath("/etc/passwd\0.jpg")).toThrow(
+        MediaFileTypeError,
+      );
+    });
+
+    it("blocks paths with null bytes before extension", () => {
+      expect(() =>
+        validateMediaFilePath("/photos/image\0.ssh/id_rsa.jpg"),
+      ).toThrow(MediaFileTypeError);
+    });
+  });
+
+  describe("double extension handling", () => {
+    it("allows double extension if final extension is media (accepted risk)", () => {
+      const result = validateMediaFilePath("/home/user/payload.env.jpg");
+      expect(result.mimeType).toBe("image/jpeg");
+    });
+  });
+
+  describe("MEDIA_ALLOWED_TYPES env var", () => {
+    it("allows extra MIME types when configured", () => {
+      const result = validateMediaFilePath("/docs/manual.pdf", {
+        allowedTypes: ["application/pdf"],
+      });
+      expect(result.mimeType).toBe("application/pdf");
+    });
+
+    it("still allows default media types when extra types are configured", () => {
+      const result = validateMediaFilePath("/photos/cat.jpg", {
+        allowedTypes: ["application/pdf"],
+      });
+      expect(result.mimeType).toBe("image/jpeg");
+    });
+
+    it("blocks types not in default or extra list", () => {
+      expect(() =>
+        validateMediaFilePath("/home/user/data.json", {
+          allowedTypes: ["application/pdf"],
+        }),
+      ).toThrow(MediaFileTypeError);
+    });
+  });
+
+  describe("MEDIA_IMPORT_DIR restriction", () => {
+    it("allows files inside the import directory", () => {
+      const result = validateMediaFilePath("/allowed/media/cat.jpg", {
+        importDir: "/allowed/media",
+      });
+      expect(result.resolvedPath).toContain("cat.jpg");
+    });
+
+    it("allows files in subdirectories of import dir", () => {
+      const result = validateMediaFilePath("/allowed/media/subdir/cat.jpg", {
+        importDir: "/allowed/media",
+      });
+      expect(result.resolvedPath).toContain("cat.jpg");
+    });
+
+    it("blocks files outside the import directory", () => {
+      expect(() =>
+        validateMediaFilePath("/other/dir/cat.jpg", {
+          importDir: "/allowed/media",
+        }),
+      ).toThrow(MediaImportDirError);
+    });
+
+    it("includes configured directory in error message", () => {
+      expect(() =>
+        validateMediaFilePath("/other/dir/cat.jpg", {
+          importDir: "/allowed/media",
+        }),
+      ).toThrow(/\/allowed\/media/);
+    });
+
+    it("does not apply directory restriction when not configured", () => {
+      // Should only check MIME type, not directory
+      const result = validateMediaFilePath("/any/path/cat.jpg");
+      expect(result.mimeType).toBe("image/jpeg");
+    });
+  });
+
+  describe("path traversal attempts", () => {
+    it("resolves path traversal before checking directory", () => {
+      // ../../../etc/passwd.jpg resolves to /etc/passwd.jpg
+      // which is outside /allowed/media and should be blocked by dir check
+      expect(() =>
+        validateMediaFilePath("/allowed/media/../../../etc/passwd.jpg", {
+          importDir: "/allowed/media",
+        }),
+      ).toThrow(MediaImportDirError);
+    });
+
+    it("allows traversal that stays within import dir", () => {
+      // /allowed/media/sub/../cat.jpg resolves to /allowed/media/cat.jpg
+      const result = validateMediaFilePath("/allowed/media/sub/../cat.jpg", {
+        importDir: "/allowed/media",
+      });
+      expect(result.mimeType).toBe("image/jpeg");
+    });
+
+    it("still validates MIME type for traversal with media extension", () => {
+      // Even with .jpg extension, path traversal is caught by dir restriction
+      // Without dir restriction, the MIME check passes (it IS an image)
+      const result = validateMediaFilePath("/etc/passwd.jpg");
+      expect(result.mimeType).toBe("image/jpeg");
+      // This is expected: MIME-only check allows it because extension is .jpg
+      // The directory restriction is the second layer of defense
+    });
+  });
+});
+
+// ── validateMediaUrl ────────────────────────────────────────────────────────
+
+describe("validateMediaUrl", () => {
+  beforeEach(() => {
+    mockLookup.mockReset();
+  });
+
+  describe("allows normal HTTP/HTTPS URLs", () => {
+    it("allows http URL", async () => {
+      mockLookup.mockResolvedValue({ address: "93.184.216.34", family: 4 });
+
+      const result = await validateMediaUrl("http://example.com/audio.mp3");
+      expect(result.hostname).toBe("example.com");
+      expect(result.resolvedIp).toBe("93.184.216.34");
+    });
+
+    it("allows https URL", async () => {
+      mockLookup.mockResolvedValue({ address: "93.184.216.34", family: 4 });
+
+      const result = await validateMediaUrl("https://example.com/image.jpg");
+      expect(result.hostname).toBe("example.com");
+      expect(result.resolvedIp).toBe("93.184.216.34");
+    });
+
+    it("allows URLs with ports", async () => {
+      mockLookup.mockResolvedValue({ address: "93.184.216.34", family: 4 });
+
+      const result = await validateMediaUrl(
+        "https://example.com:8080/file.mp3",
+      );
+      expect(result.hostname).toBe("example.com");
+    });
+  });
+
+  describe("blocks non-HTTP schemes", () => {
+    it("blocks file:// URLs", async () => {
+      await expect(validateMediaUrl("file:///etc/passwd")).rejects.toThrow(
+        MediaUrlSchemeError,
+      );
+    });
+
+    it("blocks ftp:// URLs", async () => {
+      await expect(validateMediaUrl("ftp://evil.com/file.txt")).rejects.toThrow(
+        MediaUrlSchemeError,
+      );
+    });
+
+    it("blocks gopher:// URLs", async () => {
+      await expect(validateMediaUrl("gopher://evil.com/")).rejects.toThrow(
+        MediaUrlSchemeError,
+      );
+    });
+
+    it("includes the blocked scheme in the error message", async () => {
+      await expect(validateMediaUrl("file:///etc/passwd")).rejects.toThrow(
+        /file/,
+      );
+    });
+  });
+
+  describe("blocks private/internal IPs", () => {
+    const blockedIps = [
+      // Private class A
+      ["10.0.0.1", "10.x range"],
+      ["10.255.255.255", "10.x range (high)"],
+      // Private class B
+      ["172.16.0.1", "172.16.x range"],
+      ["172.31.255.255", "172.31.x range (high)"],
+      // Private class C
+      ["192.168.0.1", "192.168.x range"],
+      ["192.168.1.100", "192.168.x range (common LAN)"],
+      // Loopback
+      ["127.0.0.1", "loopback"],
+      ["127.0.0.2", "loopback range"],
+      // Link-local / cloud metadata
+      ["169.254.169.254", "link-local (cloud metadata)"],
+      ["169.254.0.1", "link-local"],
+    ] as const;
+
+    it.each(blockedIps)("blocks %s (%s)", async (ip) => {
+      mockLookup.mockResolvedValue({ address: ip, family: 4 });
+
+      await expect(
+        validateMediaUrl("http://internal-host/file.mp3"),
+      ).rejects.toThrow(MediaUrlBlockedError);
+    });
+
+    it("provides helpful error message", async () => {
+      mockLookup.mockResolvedValue({ address: "192.168.1.1", family: 4 });
+
+      await expect(validateMediaUrl("http://my-nas/file.mp3")).rejects.toThrow(
+        /private\/internal networks/,
+      );
+    });
+
+    it("blocks 0.0.0.0 (unspecified)", async () => {
+      mockLookup.mockResolvedValue({ address: "0.0.0.0", family: 4 });
+      await expect(
+        validateMediaUrl("http://zero-host/file.mp3"),
+      ).rejects.toThrow(MediaUrlBlockedError);
+    });
+
+    it("blocks carrier-grade NAT (100.64.x.x)", async () => {
+      mockLookup.mockResolvedValue({ address: "100.64.0.1", family: 4 });
+      await expect(
+        validateMediaUrl("http://cgnat-host/file.mp3"),
+      ).rejects.toThrow(MediaUrlBlockedError);
+    });
+
+    it("blocks multicast addresses (224.x.x.x)", async () => {
+      mockLookup.mockResolvedValue({ address: "224.0.0.1", family: 4 });
+      await expect(
+        validateMediaUrl("http://multicast-host/file.mp3"),
+      ).rejects.toThrow(MediaUrlBlockedError);
+    });
+
+    it("blocks broadcast address (255.255.255.255)", async () => {
+      mockLookup.mockResolvedValue({ address: "255.255.255.255", family: 4 });
+      await expect(
+        validateMediaUrl("http://broadcast-host/file.mp3"),
+      ).rejects.toThrow(MediaUrlBlockedError);
+    });
+  });
+
+  describe("MEDIA_ALLOWED_HOSTS env var", () => {
+    it("allows whitelisted hostname", async () => {
+      mockLookup.mockResolvedValue({ address: "192.168.1.50", family: 4 });
+
+      const result = await validateMediaUrl("http://my-nas/file.mp3", {
+        allowedHosts: ["my-nas"],
+      });
+      expect(result.hostname).toBe("my-nas");
+      expect(result.resolvedIp).toBe("192.168.1.50");
+    });
+
+    it("allows whitelisted IP", async () => {
+      mockLookup.mockResolvedValue({ address: "10.0.0.5", family: 4 });
+
+      const result = await validateMediaUrl("http://internal/file.mp3", {
+        allowedHosts: ["10.0.0.5"],
+      });
+      expect(result.resolvedIp).toBe("10.0.0.5");
+    });
+
+    it("still blocks non-whitelisted private IPs", async () => {
+      mockLookup.mockResolvedValue({ address: "192.168.1.100", family: 4 });
+
+      await expect(
+        validateMediaUrl("http://other-host/file.mp3", {
+          allowedHosts: ["192.168.1.50"],
+        }),
+      ).rejects.toThrow(MediaUrlBlockedError);
+    });
+
+    it("does not bypass blocking with empty allowedHosts array", async () => {
+      mockLookup.mockResolvedValue({ address: "192.168.1.1", family: 4 });
+      await expect(
+        validateMediaUrl("http://internal/file.mp3", { allowedHosts: [] }),
+      ).rejects.toThrow(MediaUrlBlockedError);
+    });
+  });
+
+  describe("handles invalid URLs gracefully", () => {
+    it("rejects completely invalid URLs", async () => {
+      await expect(validateMediaUrl("not-a-url")).rejects.toThrow(
+        MediaUrlInvalidError,
+      );
+    });
+
+    it("rejects empty string", async () => {
+      await expect(validateMediaUrl("")).rejects.toThrow(MediaUrlInvalidError);
+    });
+
+    it("rejects URL with unresolvable hostname", async () => {
+      mockLookup.mockRejectedValue(
+        new Error("getaddrinfo ENOTFOUND no-such-host.invalid"),
+      );
+
+      await expect(
+        validateMediaUrl("http://no-such-host.invalid/file.mp3"),
+      ).rejects.toThrow(MediaUrlInvalidError);
+    });
+  });
+
+  describe("IPv6 handling", () => {
+    it("blocks IPv6 loopback", async () => {
+      mockLookup.mockResolvedValue({ address: "::1", family: 6 });
+
+      await expect(
+        validateMediaUrl("http://localhost/file.mp3"),
+      ).rejects.toThrow(MediaUrlBlockedError);
+    });
+
+    it("blocks IPv4-mapped IPv6 private addresses", async () => {
+      mockLookup.mockResolvedValue({
+        address: "::ffff:192.168.1.1",
+        family: 6,
+      });
+
+      await expect(
+        validateMediaUrl("http://internal/file.mp3"),
+      ).rejects.toThrow(MediaUrlBlockedError);
+    });
+
+    it("allows public IPv6 addresses", async () => {
+      // 2607:f8b0:4004:800::200e is a Google public IPv6 address (unicast range)
+      mockLookup.mockResolvedValue({
+        address: "2607:f8b0:4004:800::200e",
+        family: 6,
+      });
+
+      const result = await validateMediaUrl("http://ipv6host.com/file.mp3");
+      expect(result.resolvedIp).toBe("2607:f8b0:4004:800::200e");
+    });
+
+    it("blocks IPv6 unique-local (fc00::/fd00::)", async () => {
+      mockLookup.mockResolvedValue({ address: "fd12:3456:789a::1", family: 6 });
+      await expect(
+        validateMediaUrl("http://ipv6-local/file.mp3"),
+      ).rejects.toThrow(MediaUrlBlockedError);
+    });
+
+    it("blocks IPv6 literal loopback URL", async () => {
+      mockLookup.mockResolvedValue({ address: "::1", family: 6 });
+      await expect(validateMediaUrl("http://[::1]/file.mp3")).rejects.toThrow(
+        MediaUrlBlockedError,
+      );
+    });
+  });
+});
+
+// ── sanitizeMediaFilename ───────────────────────────────────────────────────
+
+describe("sanitizeMediaFilename", () => {
+  it("returns simple filenames unchanged", () => {
+    expect(sanitizeMediaFilename("photo.jpg")).toBe("photo.jpg");
+  });
+
+  it("strips ../ sequences", () => {
+    expect(sanitizeMediaFilename("../../../etc/passwd")).toBe("etcpasswd");
+  });
+
+  it("strips ../ mixed with normal path", () => {
+    expect(sanitizeMediaFilename("images/../secret.txt")).toBe(
+      "imagessecret.txt",
+    );
+  });
+
+  it("strips forward slashes", () => {
+    expect(sanitizeMediaFilename("path/to/file.jpg")).toBe("pathtofile.jpg");
+  });
+
+  it("strips backslashes", () => {
+    expect(sanitizeMediaFilename("path\\to\\file.jpg")).toBe("pathtofile.jpg");
+  });
+
+  it("handles mixed separators", () => {
+    expect(sanitizeMediaFilename("..\\..\\windows\\system32\\file.jpg")).toBe(
+      "windowssystem32file.jpg",
+    );
+  });
+
+  it("returns 'unnamed' for empty string", () => {
+    expect(sanitizeMediaFilename("")).toBe("unnamed");
+  });
+
+  it("returns 'unnamed' for whitespace-only string", () => {
+    expect(sanitizeMediaFilename("   ")).toBe("unnamed");
+  });
+
+  it("returns 'unnamed' for just dots", () => {
+    expect(sanitizeMediaFilename("....")).toBe("unnamed");
+  });
+
+  it("returns 'unnamed' for just path separators", () => {
+    expect(sanitizeMediaFilename("///")).toBe("unnamed");
+  });
+
+  it("preserves filenames with special characters", () => {
+    expect(sanitizeMediaFilename("my file (1).jpg")).toBe("my file (1).jpg");
+  });
+
+  it("preserves underscored filenames", () => {
+    expect(sanitizeMediaFilename("_audio_clip.mp3")).toBe("_audio_clip.mp3");
+  });
+
+  it("handles filename that is just ../", () => {
+    expect(sanitizeMediaFilename("../")).toBe("unnamed");
+  });
+
+  it("strips null bytes", () => {
+    expect(sanitizeMediaFilename("photo\0.jpg")).toBe("photo.jpg");
+  });
+
+  it("strips null bytes mixed with traversal", () => {
+    expect(sanitizeMediaFilename("../\0../../etc/passwd")).toBe("etcpasswd");
+  });
+});
+
+// ── Config from env helpers ─────────────────────────────────────────────────
+
+describe("getMediaFilePathConfigFromEnv", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns empty config when env vars are not set", () => {
+    delete process.env.MEDIA_ALLOWED_TYPES;
+    delete process.env.MEDIA_IMPORT_DIR;
+
+    const config = getMediaFilePathConfigFromEnv();
+    expect(config.allowedTypes).toBeUndefined();
+    expect(config.importDir).toBeUndefined();
+  });
+
+  it("parses MEDIA_ALLOWED_TYPES as comma-separated list", () => {
+    process.env.MEDIA_ALLOWED_TYPES = "application/pdf,text/plain";
+
+    const config = getMediaFilePathConfigFromEnv();
+    expect(config.allowedTypes).toEqual(["application/pdf", "text/plain"]);
+  });
+
+  it("trims whitespace from allowed types", () => {
+    process.env.MEDIA_ALLOWED_TYPES = " application/pdf , text/plain ";
+
+    const config = getMediaFilePathConfigFromEnv();
+    expect(config.allowedTypes).toEqual(["application/pdf", "text/plain"]);
+  });
+
+  it("reads MEDIA_IMPORT_DIR", () => {
+    process.env.MEDIA_IMPORT_DIR = "/home/user/anki-media";
+
+    const config = getMediaFilePathConfigFromEnv();
+    expect(config.importDir).toBe("/home/user/anki-media");
+  });
+});
+
+describe("getMediaUrlConfigFromEnv", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns empty config when env vars are not set", () => {
+    delete process.env.MEDIA_ALLOWED_HOSTS;
+
+    const config = getMediaUrlConfigFromEnv();
+    expect(config.allowedHosts).toBeUndefined();
+  });
+
+  it("parses MEDIA_ALLOWED_HOSTS as comma-separated list", () => {
+    process.env.MEDIA_ALLOWED_HOSTS = "192.168.1.50,10.0.0.5";
+
+    const config = getMediaUrlConfigFromEnv();
+    expect(config.allowedHosts).toEqual(["192.168.1.50", "10.0.0.5"]);
+  });
+
+  it("trims whitespace from allowed hosts", () => {
+    process.env.MEDIA_ALLOWED_HOSTS = " 192.168.1.50 , my-nas ";
+
+    const config = getMediaUrlConfigFromEnv();
+    expect(config.allowedHosts).toEqual(["192.168.1.50", "my-nas"]);
+  });
+});

--- a/src/mcp/utils/media-validation.utils.ts
+++ b/src/mcp/utils/media-validation.utils.ts
@@ -1,0 +1,316 @@
+/**
+ * Media validation utilities for path traversal prevention and SSRF protection.
+ *
+ * Provides three layers of defense:
+ * 1. MIME type allowlist for file paths (blocks non-media files)
+ * 2. URL/SSRF validation (blocks private/internal network requests)
+ * 3. Filename sanitization (strips path traversal sequences)
+ */
+
+import * as path from "node:path";
+import * as dns from "node:dns";
+import mime from "mime";
+import * as ipaddr from "ipaddr.js";
+
+// ── Error classes ───────────────────────────────────────────────────────────
+
+export class MediaFileTypeError extends Error {
+  constructor() {
+    super(
+      "File type not allowed. Only media files (images, audio, video) are accepted. " +
+        "To allow additional file types, set the MEDIA_ALLOWED_TYPES environment variable.",
+    );
+    this.name = "MediaFileTypeError";
+  }
+}
+
+export class MediaImportDirError extends Error {
+  constructor(configuredDir: string) {
+    super(
+      `File path is outside the allowed import directory (${configuredDir}). ` +
+        "Update MEDIA_IMPORT_DIR to change the allowed directory.",
+    );
+    this.name = "MediaImportDirError";
+  }
+}
+
+export class MediaUrlBlockedError extends Error {
+  constructor() {
+    super(
+      "URL blocked: requests to private/internal networks are not allowed. " +
+        "To allow specific hosts, set the MEDIA_ALLOWED_HOSTS environment variable.",
+    );
+    this.name = "MediaUrlBlockedError";
+  }
+}
+
+export class MediaUrlSchemeError extends Error {
+  constructor(scheme: string) {
+    super(
+      `URL scheme "${scheme}" is not allowed. Only http: and https: URLs are accepted.`,
+    );
+    this.name = "MediaUrlSchemeError";
+  }
+}
+
+export class MediaUrlInvalidError extends Error {
+  constructor() {
+    super("Invalid URL provided.");
+    this.name = "MediaUrlInvalidError";
+  }
+}
+
+// ── Config interfaces ───────────────────────────────────────────────────────
+
+export interface MediaFilePathConfig {
+  /** Extra MIME types to allow beyond the default media types (e.g., ["application/pdf"]) */
+  allowedTypes?: string[];
+  /** If set, resolved file path must be inside this directory */
+  importDir?: string;
+}
+
+export interface MediaUrlConfig {
+  /** Hostnames or IPs that are allowed even if they resolve to private ranges */
+  allowedHosts?: string[];
+}
+
+// ── Default allowed MIME type prefixes ──────────────────────────────────────
+
+const DEFAULT_ALLOWED_PREFIXES = ["image/", "audio/", "video/"];
+
+// ── IP ranges that should be blocked for SSRF prevention ────────────────────
+
+const BLOCKED_RANGES = new Set([
+  "private",
+  "loopback",
+  "linkLocal",
+  "reserved",
+  "unspecified",
+  // IPv6-specific blocked ranges
+  "uniqueLocal",
+  // Additional ranges
+  "carrierGradeNat",
+  "multicast",
+  "broadcast",
+]);
+
+// ── Path validation ─────────────────────────────────────────────────────────
+
+/**
+ * Validate a local file path for media import.
+ *
+ * Checks:
+ * 1. File extension resolves to an allowed MIME type (image/*, audio/*, video/* by default)
+ * 2. If importDir is configured, the resolved path must be inside that directory
+ *
+ * @throws MediaFileTypeError if the MIME type is not allowed
+ * @throws MediaImportDirError if the path is outside the allowed directory
+ */
+export function validateMediaFilePath(
+  filePath: string,
+  config: MediaFilePathConfig = {},
+): { resolvedPath: string; mimeType: string } {
+  // Reject null bytes to prevent injection bypasses
+  if (filePath.includes("\0")) {
+    throw new MediaFileTypeError();
+  }
+
+  const resolvedPath = path.resolve(filePath);
+  const detectedMime = mime.getType(resolvedPath);
+
+  // Check MIME type against allowlist
+  const isDefaultAllowed =
+    detectedMime !== null &&
+    DEFAULT_ALLOWED_PREFIXES.some((prefix) => detectedMime.startsWith(prefix));
+
+  const isExtraAllowed =
+    detectedMime !== null &&
+    config.allowedTypes !== undefined &&
+    config.allowedTypes.includes(detectedMime);
+
+  if (!isDefaultAllowed && !isExtraAllowed) {
+    throw new MediaFileTypeError();
+  }
+
+  // Check directory restriction if configured
+  if (config.importDir) {
+    const resolvedImportDir = path.resolve(config.importDir);
+    // Ensure the import dir path ends with separator for prefix matching
+    const normalizedImportDir = resolvedImportDir.endsWith(path.sep)
+      ? resolvedImportDir
+      : resolvedImportDir + path.sep;
+
+    if (!resolvedPath.startsWith(normalizedImportDir)) {
+      throw new MediaImportDirError(config.importDir);
+    }
+  }
+
+  return { resolvedPath, mimeType: detectedMime };
+}
+
+// ── URL/SSRF validation ─────────────────────────────────────────────────────
+
+/**
+ * Validate a URL for SSRF safety before allowing it to be fetched by AnkiConnect.
+ *
+ * Checks:
+ * 1. URL is valid and parseable
+ * 2. Scheme is http: or https:
+ * 3. Resolved IP is not in a private/reserved range (unless host is in allowedHosts)
+ *
+ * NOTE: This validation is subject to DNS rebinding (TOCTOU). We resolve and validate the IP here,
+ * but AnkiConnect re-resolves the hostname when fetching. An attacker controlling DNS could return
+ * a public IP for our check and a private IP for AnkiConnect's fetch. This is an inherent limitation
+ * when we cannot control the downstream HTTP client.
+ *
+ * @throws MediaUrlInvalidError if the URL cannot be parsed
+ * @throws MediaUrlSchemeError if the scheme is not http(s)
+ * @throws MediaUrlBlockedError if the resolved IP is in a blocked range
+ */
+export async function validateMediaUrl(
+  input: string,
+  config: MediaUrlConfig = {},
+): Promise<{ hostname: string; resolvedIp: string }> {
+  // Parse URL
+  let parsed: URL;
+  try {
+    parsed = new URL(input);
+  } catch {
+    throw new MediaUrlInvalidError();
+  }
+
+  // Check scheme
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new MediaUrlSchemeError(parsed.protocol.replace(":", ""));
+  }
+
+  const hostname = parsed.hostname;
+
+  // Strip brackets from IPv6 literals for DNS lookup (e.g., "[::1]" → "::1")
+  const hostnameForLookup =
+    hostname.startsWith("[") && hostname.endsWith("]")
+      ? hostname.slice(1, -1)
+      : hostname;
+
+  // Resolve hostname to IP
+  let resolvedIp: string;
+  try {
+    const result = await dns.promises.lookup(hostnameForLookup);
+    resolvedIp = result.address;
+  } catch {
+    throw new MediaUrlInvalidError();
+  }
+
+  // Check if host is in the allowed list (skip range check if so)
+  if (config.allowedHosts && config.allowedHosts.length > 0) {
+    const isAllowed = config.allowedHosts.some(
+      (allowed) => allowed === hostname || allowed === resolvedIp,
+    );
+    if (isAllowed) {
+      return { hostname, resolvedIp };
+    }
+  }
+
+  // Parse and check IP range
+  let addr: ipaddr.IPv4 | ipaddr.IPv6;
+  try {
+    addr = ipaddr.parse(resolvedIp);
+  } catch {
+    throw new MediaUrlBlockedError();
+  }
+
+  // For IPv4-mapped IPv6 addresses, extract the IPv4 part
+  if (addr.kind() === "ipv6") {
+    const ipv6 = addr as ipaddr.IPv6;
+    if (ipv6.isIPv4MappedAddress()) {
+      addr = ipv6.toIPv4Address();
+    }
+  }
+
+  const range = addr.range();
+  if (BLOCKED_RANGES.has(range)) {
+    throw new MediaUrlBlockedError();
+  }
+
+  return { hostname, resolvedIp };
+}
+
+// ── Filename sanitization ───────────────────────────────────────────────────
+
+/**
+ * Sanitize a media filename by stripping path traversal sequences and extracting basename.
+ *
+ * - Strips null bytes
+ * - Removes `..` sequences
+ * - Strips path separators (`/`, `\`)
+ * - Returns `path.basename()` of the cleaned result
+ * - Returns "unnamed" for empty/invalid results
+ */
+export function sanitizeMediaFilename(filename: string): string {
+  // Strip null bytes
+  let sanitized = filename.replace(/\0/g, "");
+
+  // Remove .. sequences
+  sanitized = sanitized.replace(/\.\./g, "");
+
+  // Remove path separators
+  sanitized = sanitized.replace(/[/\\]/g, "");
+
+  // Extract basename (handles any remaining edge cases)
+  sanitized = path.basename(sanitized);
+
+  // Fallback for empty results
+  if (!sanitized || sanitized.trim() === "" || sanitized === ".") {
+    return "unnamed";
+  }
+
+  return sanitized;
+}
+
+// ── Convenience functions that read from process.env ────────────────────────
+
+/**
+ * Build MediaFilePathConfig from environment variables.
+ *
+ * Reads:
+ * - MEDIA_ALLOWED_TYPES: comma-separated list of additional MIME types
+ * - MEDIA_IMPORT_DIR: directory restriction for file paths
+ */
+export function getMediaFilePathConfigFromEnv(): MediaFilePathConfig {
+  const config: MediaFilePathConfig = {};
+
+  const allowedTypes = process.env.MEDIA_ALLOWED_TYPES;
+  if (allowedTypes) {
+    config.allowedTypes = allowedTypes
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+  }
+
+  const importDir = process.env.MEDIA_IMPORT_DIR;
+  if (importDir) {
+    config.importDir = importDir;
+  }
+
+  return config;
+}
+
+/**
+ * Build MediaUrlConfig from environment variables.
+ *
+ * Reads:
+ * - MEDIA_ALLOWED_HOSTS: comma-separated list of allowed hostnames or IPs
+ */
+export function getMediaUrlConfigFromEnv(): MediaUrlConfig {
+  const config: MediaUrlConfig = {};
+
+  const allowedHosts = process.env.MEDIA_ALLOWED_HOSTS;
+  if (allowedHosts) {
+    config.allowedHosts = allowedHosts
+      .split(",")
+      .map((h) => h.trim())
+      .filter(Boolean);
+  }
+
+  return config;
+}


### PR DESCRIPTION
## Summary

- Add MIME type allowlist for file path imports (image/*, audio/*, video/* only)
- Add SSRF prevention for URL imports (block private IPs, non-HTTP schemes, cloud metadata)
- Add filename sanitization (strip path traversal sequences)
- Add null byte injection protection
- New env vars: `MEDIA_ALLOWED_TYPES`, `MEDIA_IMPORT_DIR`, `MEDIA_ALLOWED_HOSTS`
- New deps: `mime@4` (MIME lookup), `ipaddr.js@2` (IP classification)
- 131 new tests (775 total)

Reported-by: [Hideaki Takahashi](https://github.com/Koukyosyumei)

## Test plan

- [x] Unit tests for all three validators (MIME, SSRF, filename) — 105 tests
- [x] Integration tests verifying guards are wired into tool execution — 26 tests
- [x] Type check passes
- [x] Lint passes (0 errors)
- [x] Live sanity tests against local Anki instance:
  - `path: ~/.ssh/id_rsa` → blocked
  - `path: ~/.env` → blocked
  - `path: /etc/passwd` → blocked
  - `url: file:///etc/passwd` → blocked
  - `url: http://169.254.169.254/...` → blocked
  - Public HTTPS URL → works
  - `getMediaFilesNames` → works
  - `findNotes` → works

🤖 Generated with [Claude Code](https://claude.com/claude-code)