### PR TITLE
fix(anki-connect): serialize requests to prevent parallel-call timeouts

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -61,11 +61,11 @@
     },
     {
       "name": "addNote",
-      "description": "Create new notes with specified fields and tags. IMPORTANT: Only create notes that were explicitly requested by the user"
+      "description": "Add a SINGLE note. To create multiple notes, use addNotes instead of calling addNote repeatedly — AnkiConnect processes requests one at a time, so repeated/parallel addNote calls are slower and unnecessary. IMPORTANT: Only create notes that were explicitly requested by the user"
     },
     {
       "name": "addNotes",
-      "description": "Add multiple notes to Anki in a single batch. Up to 100 notes sharing the same deck and model. Duplicates are skipped individually; validation errors (empty required fields, bad tags) reject the batch."
+      "description": "Add multiple notes in a single batch — the preferred way to create more than one note (use instead of repeated addNote calls). Up to 100 notes sharing the same deck and model. Duplicates are skipped individually; validation errors (empty required fields, bad tags) reject the batch."
     },
     {
       "name": "findNotes",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.1.26",
         "@rekog/mcp-nest": "^1.9.10",
+        "async-mutex": "^0.5.0",
         "commander": "^15.0.0",
         "ipaddr.js": "^2.4.0",
         "jsonwebtoken": "^9.0.3",
@@ -6762,6 +6763,15 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.1.26",
     "@rekog/mcp-nest": "^1.9.10",
+    "async-mutex": "^0.5.0",
     "commander": "^15.0.0",
     "ipaddr.js": "^2.4.0",
     "jsonwebtoken": "^9.0.3",

--- a/src/mcp/clients/__tests__/anki-connect.client.spec.ts
+++ b/src/mcp/clients/__tests__/anki-connect.client.spec.ts
@@ -4,6 +4,7 @@ import {
   AnkiConnectClient,
   AnkiConnectError,
   ReadOnlyModeError,
+  __resetAnkiQueueForTests,
 } from "../anki-connect.client";
 import { ANKI_CONFIG } from "@/mcp/config/anki-config.interface";
 import type { IAnkiConfig } from "@/mcp/config/anki-config.interface";
@@ -137,6 +138,11 @@ describe("AnkiConnectClient", () => {
   });
 
   afterEach(() => {
+    // Reset the module-scoped pending-request counter so serialization specs
+    // don't leak queue depth into later tests (a wedged counter would trip the
+    // backpressure guard). Individual serialization tests resolve any held
+    // blockers in their own `finally` so the mutex itself is never left locked.
+    __resetAnkiQueueForTests();
     jest.restoreAllMocks();
   });
 
@@ -1581,6 +1587,237 @@ describe("AnkiConnectClient", () => {
       expect(callArg.action).toBe("noParamsAction");
       expect(callArg.version).toBe(6);
       // params is undefined, not included or is undefined
+    });
+  });
+
+  describe("invoke() - Request Serialization", () => {
+    // The client performs "the HTTP call" only when it awaits `.json()`, so by
+    // controlling when each per-request promise settles we get precise control
+    // over completion order — no real timers, no races. Each mocked POST
+    // registers its resolve/reject in these registries, keyed by call order.
+    type Resolver = (result: unknown) => void;
+    type Rejecter = (err: unknown) => void;
+    let resolvers: Resolver[] = [];
+    let rejecters: Rejecter[] = [];
+
+    // Let microtasks flush so queued mutex callbacks can advance.
+    const flush = () => new Promise<void>((r) => setImmediate(r));
+
+    /**
+     * Registry-based deferred mock: each POST registers its resolve/reject in
+     * `resolvers`/`rejecters` (indexed by call order), and tracks in-flight /
+     * start / finish ordering so tests can assert serialization invariants.
+     * `.json()` being invoked is the moment a request is actually "in flight".
+     */
+    function installRegistryMock() {
+      resolvers = [];
+      rejecters = [];
+      const startOrder: string[] = [];
+      const finishOrder: string[] = [];
+      let inFlight = 0;
+      let maxInFlight = 0;
+
+      mockKyInstance.post.mockImplementation(
+        (_endpoint: string, options: { json: { action: string } }) => {
+          const action = options.json.action;
+          const promise = new Promise((resolve, reject) => {
+            resolvers.push((result: unknown) => {
+              finishOrder.push(action);
+              inFlight--;
+              resolve({ result, error: null });
+            });
+            rejecters.push((err: unknown) => {
+              inFlight--;
+              reject(err);
+            });
+          });
+          return {
+            json: () => {
+              startOrder.push(action);
+              inFlight++;
+              maxInFlight = Math.max(maxInFlight, inFlight);
+              return promise;
+            },
+          };
+        },
+      );
+
+      return {
+        startOrder,
+        finishOrder,
+        getInFlight: () => inFlight,
+        getMaxInFlight: () => maxInFlight,
+      };
+    }
+
+    it("executes concurrently-fired requests FIFO, one at a time, in submission order", async () => {
+      const mock = installRegistryMock();
+      const actions = ["a1", "a2", "a3", "a4", "a5"];
+
+      // Fire all five concurrently WITHOUT awaiting individually.
+      const promises = actions.map((action) => client.invoke(action));
+
+      // Drive the queue one request at a time. After each flush exactly one new
+      // request (the next in submission order) should have started its HTTP
+      // call, proving FIFO serialization with at most one request in flight.
+      for (let i = 0; i < actions.length; i++) {
+        await flush();
+        expect(mock.startOrder).toEqual(actions.slice(0, i + 1));
+        expect(mock.getInFlight()).toBe(1);
+        // Release the current in-flight request so the next may proceed.
+        resolvers[i](`res-${actions[i]}`);
+      }
+
+      const results = await Promise.all(promises);
+      expect(results).toEqual(actions.map((a) => `res-${a}`));
+      // Both started and finished strictly in submission order.
+      expect(mock.startOrder).toEqual(actions);
+      expect(mock.finishOrder).toEqual(actions);
+      // The core proof: never more than one HTTP call in flight at once.
+      expect(mock.getMaxInFlight()).toBe(1);
+    });
+
+    it("never lets a second request start before the first settles (no overlap)", async () => {
+      const mock = installRegistryMock();
+
+      const p1 = client.invoke("first");
+      const p2 = client.invoke("second");
+
+      await flush();
+      // Only the first request should be in flight; second still queued.
+      expect(mock.startOrder).toEqual(["first"]);
+      expect(mock.getInFlight()).toBe(1);
+
+      // Resolve the first; the second should now be allowed to start.
+      resolvers[0]("ok-1");
+      await flush();
+      expect(mock.startOrder).toEqual(["first", "second"]);
+      expect(mock.getInFlight()).toBe(1);
+
+      resolvers[1]("ok-2");
+      const [r1, r2] = await Promise.all([p1, p2]);
+      expect(r1).toBe("ok-1");
+      expect(r2).toBe("ok-2");
+      expect(mock.getMaxInFlight()).toBe(1);
+    });
+
+    it("releases the slot when a request fails, letting the next proceed", async () => {
+      const mock = installRegistryMock();
+
+      const p1 = client.invoke("willFail");
+      const p2 = client.invoke("willSucceed");
+
+      await flush();
+      expect(mock.startOrder).toEqual(["willFail"]);
+
+      // Reject the first request (simulates a timeout / network failure). The
+      // mutex must release so the second request is not deadlocked behind it.
+      rejecters[0](
+        new Error("The operation was aborted due to timeout (fetch)"),
+      );
+
+      await expect(p1).rejects.toThrow(AnkiConnectError);
+
+      await flush();
+      // Second request must have started despite the first failing.
+      expect(mock.startOrder).toEqual(["willFail", "willSucceed"]);
+      expect(mock.getInFlight()).toBe(1);
+
+      resolvers[1]("recovered");
+      await expect(p2).resolves.toBe("recovered");
+      expect(mock.getMaxInFlight()).toBe(1);
+    });
+
+    it("rejects the 51st request immediately without calling the HTTP layer, then recovers", async () => {
+      const mock = installRegistryMock();
+      const blockers: Promise<unknown>[] = [];
+
+      try {
+        // Saturate the queue: MAX_QUEUE_DEPTH (50) pending requests. The first
+        // is in flight; the other 49 are queued on the mutex. None resolve yet.
+        for (let i = 0; i < 50; i++) {
+          blockers.push(client.invoke(`held-${i}`).catch(() => "caught"));
+        }
+        await flush();
+
+        // Exactly one is in flight (serialized); the rest wait on the mutex.
+        expect(mock.getInFlight()).toBe(1);
+        const postCallsBefore = mockKyInstance.post.mock.calls.length;
+
+        // The 51st invoke must reject IMMEDIATELY (queue depth at cap) and must
+        // NOT reach the HTTP layer.
+        await expect(client.invoke("overflow")).rejects.toThrow(
+          AnkiConnectError,
+        );
+        await expect(client.invoke("overflow")).rejects.toThrow(/addNotes/);
+
+        // No new POST was issued for the rejected overflow requests.
+        expect(mockKyInstance.post.mock.calls.length).toBe(postCallsBefore);
+        expect(mock.startOrder).not.toContain("overflow");
+      } finally {
+        // Drain every held request so the mutex is freed for later tests.
+        // Only the in-flight request has registered a resolver; releasing it
+        // lets the next queued request start and register ITS resolver. So we
+        // resolve-then-flush in a loop until all 50 blockers have settled.
+        let drained = 0;
+        while (drained < resolvers.length) {
+          resolvers[drained](`done-${drained}`);
+          drained++;
+          await flush();
+        }
+        await Promise.all(blockers);
+      }
+
+      // Recovery: with the queue drained, a fresh invoke succeeds normally.
+      installRegistryMock();
+      const recovered = client.invoke("afterDrain");
+      await flush();
+      resolvers[0]("recovered-ok");
+      await expect(recovered).resolves.toBe("recovered-ok");
+    });
+
+    it("does not enqueue or call HTTP when read-only blocks a write, leaving the counter intact", async () => {
+      const readOnlyConfig: IAnkiConfig = {
+        ...mockConfig,
+        readOnly: true,
+      };
+      const module = await Test.createTestingModule({
+        providers: [
+          AnkiConnectClient,
+          { provide: ANKI_CONFIG, useValue: readOnlyConfig },
+        ],
+      }).compile();
+      const readOnlyClient = module.get<AnkiConnectClient>(AnkiConnectClient);
+
+      const mock = installRegistryMock();
+
+      // A blocked write rejects with ReadOnlyModeError BEFORE the mutex/counter,
+      // so the HTTP layer is never touched.
+      await expect(
+        readOnlyClient.invoke("addNote", { note: {} }),
+      ).rejects.toBeInstanceOf(ReadOnlyModeError);
+      expect(mockKyInstance.post).not.toHaveBeenCalled();
+
+      // Counter unaffected: an allowed read still goes through and completes,
+      // proving the blocked write neither incremented nor wedged the counter.
+      const allowed = readOnlyClient.invoke("deckNames");
+      await flush();
+      expect(mock.getInFlight()).toBe(1);
+      resolvers[0](["Default"]);
+      await expect(allowed).resolves.toEqual(["Default"]);
+    });
+
+    it("still maps a response.error to AnkiConnectError through the serialized path", async () => {
+      // Sanity: serialization wrapper hasn't broken normal error mapping.
+      mockKyInstance.post.mockReturnValue({
+        json: jest
+          .fn()
+          .mockResolvedValue({ result: null, error: "deck not found" }),
+      });
+
+      await expect(client.invoke("findCards")).rejects.toThrow(
+        "AnkiConnect error: deck not found",
+      );
     });
   });
 });

--- a/src/mcp/clients/anki-connect.client.ts
+++ b/src/mcp/clients/anki-connect.client.ts
@@ -1,8 +1,43 @@
 import { Inject, Injectable, Logger } from "@nestjs/common";
+import { Mutex } from "async-mutex";
 import ky, { KyInstance, HTTPError } from "ky";
 import { ANKI_CONFIG } from "../config/anki-config.interface";
 import type { IAnkiConfig } from "../config/anki-config.interface";
 import { AnkiConnectRequest, AnkiConnectResponse } from "../types/anki.types";
+
+/**
+ * AnkiConnect is single-threaded (requests run on Anki's Qt main thread with
+ * max_workers=1), so concurrent POSTs collide and time out. All requests —
+ * reads included — are serialized through this mutex (concurrency 1, FIFO).
+ *
+ * Module-scoped on purpose: AnkiConnectClient is provided by both the
+ * essential and GUI modules, so NestJS may create multiple instances. A
+ * single file-level mutex serializes across all of them, matching the
+ * "one Anki per process" invariant.
+ */
+const ankiRequestMutex = new Mutex();
+
+/**
+ * Maximum number of requests allowed to be pending (in-flight + queued) at
+ * once. Beyond this we fail fast instead of queueing unbounded work — the
+ * error message steers the AI toward the addNotes batch tool, which awaits
+ * sequentially and keeps queue depth ~1.
+ */
+const MAX_QUEUE_DEPTH = 50;
+
+/** Current number of pending requests (in-flight + waiting on the mutex). */
+let pendingRequests = 0;
+
+/**
+ * @internal test-only — resets the module-scoped pending-request counter so
+ * serialization specs don't leak queue depth across tests (a wedged counter
+ * would otherwise trip the backpressure guard in later tests). The mutex
+ * itself auto-frees once every in-flight `runExclusive` callback settles, so
+ * only the counter needs an explicit reset. Not part of the public API.
+ */
+export function __resetAnkiQueueForTests(): void {
+  pendingRequests = 0;
+}
 
 /**
  * Set of AnkiConnect actions that modify collection content.
@@ -87,6 +122,9 @@ export class AnkiConnectClient {
       headers: {
         "Content-Type": "application/json",
       },
+      // Note: timeouts are intentionally NOT retried (no retryOnTimeout), so
+      // the time a request can hold the serialization mutex stays bounded by
+      // ankiConnectTimeout (plus the listed retryable HTTP statuses).
       retry: {
         limit: 2,
         methods: ["POST"],
@@ -140,26 +178,53 @@ export class AnkiConnectClient {
       request.key = this.apiKey;
     }
 
+    // Backpressure guard: fail fast instead of queueing unbounded work.
+    if (pendingRequests >= MAX_QUEUE_DEPTH) {
+      this.logger.warn(
+        `Rejecting action "${action}": ${pendingRequests} requests already pending (max ${MAX_QUEUE_DEPTH})`,
+      );
+      throw new AnkiConnectError(
+        `Too many concurrent requests queued for AnkiConnect (max ${MAX_QUEUE_DEPTH}). ` +
+          `For bulk note creation, use the addNotes batch tool instead of many parallel addNote calls.`,
+        action,
+      );
+    }
+
+    // Enqueue synchronously (no await between here and runExclusive) so FIFO
+    // order matches submission order.
+    pendingRequests++;
+
     try {
-      this.logger.log(`Invoking AnkiConnect action: ${action}`);
+      // Acquire the mutex BEFORE dispatching, so ky's timeout (which starts
+      // at POST dispatch) covers only the in-flight request, never the time
+      // spent waiting in the queue. runExclusive releases the lock even if
+      // the callback throws.
+      const result = await ankiRequestMutex.runExclusive(async () => {
+        this.logger.log(`Invoking AnkiConnect action: ${action}`);
 
-      const response = await this.client
-        .post("", {
-          json: request,
-        })
-        .json<AnkiConnectResponse<T>>();
+        const response = await this.client
+          .post("", {
+            json: request,
+          })
+          .json<AnkiConnectResponse<T>>();
 
-      // Check for AnkiConnect errors
-      if (response.error) {
-        throw new AnkiConnectError(
-          `AnkiConnect error: ${response.error}`,
-          action,
-          response.error,
-        );
-      }
+        // Check for AnkiConnect errors
+        if (response.error) {
+          throw new AnkiConnectError(
+            `AnkiConnect error: ${response.error}`,
+            action,
+            response.error,
+          );
+        }
 
-      this.logger.log(`AnkiConnect action successful: ${action}`);
-      return response.result;
+        // Log success while still holding the mutex so the per-request log
+        // order ("Invoking" → "successful") can't interleave with the next
+        // request's "Invoking" line.
+        this.logger.log(`AnkiConnect action successful: ${action}`);
+        return response.result;
+      });
+
+      return result;
     } catch (error) {
       // Re-throw ReadOnlyModeError without wrapping
       if (error instanceof ReadOnlyModeError) {
@@ -198,6 +263,8 @@ export class AnkiConnectClient {
         `Unexpected error: ${error instanceof Error ? error.message : String(error)}`,
         action,
       );
+    } finally {
+      pendingRequests--;
     }
   }
 }

--- a/src/mcp/primitives/essential/tools/add-note.tool.ts
+++ b/src/mcp/primitives/essential/tools/add-note.tool.ts
@@ -17,7 +17,7 @@ export class AddNoteTool {
   @Tool({
     name: "addNote",
     description:
-      "Add a new note to Anki. Use modelNames to see available note types and modelFieldNames to see required fields. Returns the note ID on success. IMPORTANT: Only create notes that were explicitly requested by the user.",
+      "Add a SINGLE note to Anki. To create multiple notes, use the addNotes batch tool instead of calling addNote repeatedly — AnkiConnect processes requests one at a time, so repeated (especially parallel) addNote calls are slower and unnecessary. Use modelNames to see available note types and modelFieldNames to see required fields. Returns the note ID on success. IMPORTANT: Only create notes that were explicitly requested by the user.",
     parameters: z.object({
       deckName: z.string().min(1).describe("The deck to add the note to"),
       modelName: z

--- a/src/mcp/primitives/essential/tools/add-notes.tool.ts
+++ b/src/mcp/primitives/essential/tools/add-notes.tool.ts
@@ -32,7 +32,7 @@ export class AddNotesTool {
   @Tool({
     name: "addNotes",
     description:
-      "Add multiple notes to Anki in a single batch. Up to 100 notes sharing the same deck and model. Duplicates are skipped individually; validation errors (empty required fields, bad tags) reject the batch. IMPORTANT: Only create notes that were explicitly requested by the user.",
+      "Add multiple notes to Anki in a single batch — the preferred way to create more than one note (use this instead of repeated addNote calls). Up to 100 notes sharing the same deck and model. Duplicates are skipped individually; validation errors (empty required fields, bad tags) reject the batch. IMPORTANT: Only create notes that were explicitly requested by the user.",
     parameters: z.object({
       deckName: z.string().min(1).describe("The deck to add all notes to"),
       modelName: z


### PR DESCRIPTION
**Draft for morning review — do not merge yet.** Generated autonomously overnight per the agreed pipeline (fable validate → fable implement → fable review → opus fix → opus tests).

## Problem
AnkiConnect runs single-threaded on Anki's Qt main thread (`TaskManager(max_workers=1)`). When an MCP client (e.g. Claude Desktop) fires multiple `addNote` calls in parallel, our server forwards them as concurrent POSTs; they collide and hit the 5s `ANKI_CONNECT_TIMEOUT`, producing the `Sibling tool call errored` cascade. Fixes #23 (and the root cause behind #22). Note the actual failing call in #22 was a **read** (`modelFieldNames`), so reads must be serialized too.

## Change
Serialize all AnkiConnect requests through a **module-scoped `async-mutex`** (concurrency 1) in `AnkiConnectClient.invoke()`:

- **One request in flight at a time, FIFO** by submission order.
- **Lock acquired before dispatch** → in-queue wait never counts against ky's per-request timeout (the key correctness point).
- **Reads serialized too** (the #22 failure was a read).
- **Read-only guard stays before enqueue** — blocked writes never consume a slot.
- **Backpressure**: `MAX_QUEUE_DEPTH = 50`; the 51st pending request rejects immediately with an `AnkiConnectError` steering to `addNotes` (a legit sequential `addNotes` batch keeps depth ~1).
- **Module-scoped** (not per-instance) because `AnkiConnectClient` is declared in both the essential and GUI module providers — one queue per process matches the one-Anki-per-process invariant regardless of DI instance count.
- ky retry config untouched; timeouts remain non-retried so a held slot stays bounded by `ankiConnectTimeout`.

`async-mutex` (CJS) chosen over `p-limit` (ESM, would need Jest `transformIgnorePatterns`).

## Tests
6 new unit tests: FIFO/one-at-a-time, no-overlap (`maxInFlight === 1`), failure-releases-slot (no deadlock), depth-guard rejection + recovery, read-only-does-not-enqueue, error-mapping intact. **114/114 pass**, type-check + lint clean.

## Residual risks (honest)
- **Multi-process deployments** (stdio + HTTP/tunnel running simultaneously = two Node processes) are not serialized across processes — no worse than today; low-rate cross-client overlap is what AnkiConnect already tolerates.
- **Deep queues** can still hit the *MCP client's own* response timeout — mitigated by fast ops + the `addNotes` steering from #23's description changes (which should land alongside this).

## For the reviewer to weigh
- Is `MAX_QUEUE_DEPTH = 50` the right cap?
- The pre-existing dead `ReadOnlyModeError` catch branch was left untouched to keep the diff focused.
- `#23`'s description steering (`addNote` → `addNotes`) is a complementary follow-up, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — now also includes #23's description steering (folded in from the former #30)

To keep #23 resolved by a single PR, this now also reframes the tool descriptions:
- `addNote` → described as **single-note**; points to `addNotes` for multiples.
- `addNotes` → reframed as the **preferred** batch path.
- `manifest.json` mirror updated.

So #29 fully resolves #23: serialization (root cause) **+** description steering (the clarity ask), together.
