### PR TITLE
fix(tools): steer addNote toward addNotes for batch creation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -61,11 +61,11 @@
     },
     {
       "name": "addNote",
-      "description": "Create new notes with specified fields and tags. IMPORTANT: Only create notes that were explicitly requested by the user"
+      "description": "Add a SINGLE note. To create multiple notes, use addNotes instead of calling addNote repeatedly — AnkiConnect processes requests one at a time, so repeated/parallel addNote calls are slower and unnecessary. IMPORTANT: Only create notes that were explicitly requested by the user"
     },
     {
       "name": "addNotes",
-      "description": "Add multiple notes to Anki in a single batch. Up to 100 notes sharing the same deck and model. Duplicates are skipped individually; validation errors (empty required fields, bad tags) reject the batch."
+      "description": "Add multiple notes in a single batch — the preferred way to create more than one note (use instead of repeated addNote calls). Up to 100 notes sharing the same deck and model. Duplicates are skipped individually; validation errors (empty required fields, bad tags) reject the batch."
     },
     {
       "name": "findNotes",

--- a/src/mcp/primitives/essential/tools/add-note.tool.ts
+++ b/src/mcp/primitives/essential/tools/add-note.tool.ts
@@ -17,7 +17,7 @@ export class AddNoteTool {
   @Tool({
     name: "addNote",
     description:
-      "Add a new note to Anki. Use modelNames to see available note types and modelFieldNames to see required fields. Returns the note ID on success. IMPORTANT: Only create notes that were explicitly requested by the user.",
+      "Add a SINGLE note to Anki. To create multiple notes, use the addNotes batch tool instead of calling addNote repeatedly — AnkiConnect processes requests one at a time, so repeated (especially parallel) addNote calls are slower and unnecessary. Use modelNames to see available note types and modelFieldNames to see required fields. Returns the note ID on success. IMPORTANT: Only create notes that were explicitly requested by the user.",
     parameters: z.object({
       deckName: z.string().min(1).describe("The deck to add the note to"),
       modelName: z

--- a/src/mcp/primitives/essential/tools/add-notes.tool.ts
+++ b/src/mcp/primitives/essential/tools/add-notes.tool.ts
@@ -32,7 +32,7 @@ export class AddNotesTool {
   @Tool({
     name: "addNotes",
     description:
-      "Add multiple notes to Anki in a single batch. Up to 100 notes sharing the same deck and model. Duplicates are skipped individually; validation errors (empty required fields, bad tags) reject the batch. IMPORTANT: Only create notes that were explicitly requested by the user.",
+      "Add multiple notes to Anki in a single batch — the preferred way to create more than one note (use this instead of repeated addNote calls). Up to 100 notes sharing the same deck and model. Duplicates are skipped individually; validation errors (empty required fields, bad tags) reject the batch. IMPORTANT: Only create notes that were explicitly requested by the user.",
     parameters: z.object({
       deckName: z.string().min(1).describe("The deck to add all notes to"),
       modelName: z


### PR DESCRIPTION
Steers agents toward the `addNotes` batch tool instead of repeated/parallel `addNote` calls, by reframing the tool descriptions (and their `manifest.json` mirror). Addresses the description-clarity ask in #23.

## Changes
- **`addNote`** — now described as adding a **single** note; tells the agent to use `addNotes` for multiple, noting that AnkiConnect processes requests one at a time so repeated/parallel `addNote` calls are slower and unnecessary.
- **`addNotes`** — reframed as the **preferred** path for creating more than one note.
- **`manifest.json`** — both descriptions mirrored (the separate copy MCPB clients read).

## Notes
- Wording is deliberately "slower / unnecessary," **not** "will time out" — once the request serialization in #29 lands, parallel calls queue instead of failing, so a timeout claim would become inaccurate. This phrasing stays correct either way.
- This is the **complement** to #29, not a substitute: descriptions only *nudge* the model, they don't *prevent* parallel calls. #29 (serialize requests in `AnkiConnectClient`) is the root-cause fix for the timeouts reported in #22; this PR reduces how often an agent reaches for the wrong tool in the first place.

Descriptions-only change — no logic touched. type-check + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
