### PR TITLE
fix(security): reject untrusted Host headers (DNS-rebinding protection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ For client-specific features and troubleshooting, consult your MCP client's docu
 
 HTTP mode runs the server as a local web server speaking the MCP Streamable HTTP protocol. It's the transport a web-based AI tool talks to when pointed at your machine, and it's also what the [Remote](#remote) options expose to the outside world. On its own, HTTP mode binds to `localhost` only.
 
+> **Binding beyond localhost?** If you pass `--host 0.0.0.0` (or run behind a reverse proxy/public domain), the server only accepts loopback `Host` headers by default for DNS-rebinding protection — set `ALLOWED_HOSTS` to the hostname(s) clients use. See [HTTP Mode Configuration](#http-mode-configuration).
+
 **Setup - Choose one method:**
 
 **Method 1: Using npx (recommended - no installation needed)**
@@ -330,7 +332,9 @@ If you'd rather expose [local HTTP mode](#http-local-web-based-ai) publicly with
 ankimcp --ngrok
 ```
 
-This route is **unauthenticated** — anyone with the URL can reach your Anki, so it's less secure than [Tunnel](#tunnel--recommended). Prefer Tunnel unless you have a specific reason to manage your own ngrok endpoint. (Requires a global ngrok install and authtoken; the manual two-terminal `ngrok http 3000` setup works too.)
+This route is **unauthenticated** — anyone with the URL can reach your Anki, so it's less secure than [Tunnel](#tunnel--recommended). Prefer Tunnel unless you have a specific reason to manage your own ngrok endpoint. (Requires a global ngrok install and authtoken.)
+
+The `--ngrok` flag launches ngrok with `--host-header=rewrite`, so ngrok rewrites the upstream `Host` to `localhost` before forwarding. That keeps requests within the loopback Host allowlist (see [DNS-rebinding protection](#http-mode-configuration)) without you having to add the public `*.ngrok` domain to `ALLOWED_HOSTS`. If you instead run ngrok manually, use the same flag — `ngrok http --host-header=rewrite 3000` — otherwise ngrok forwards the public ngrok hostname as `Host` and the server rejects it with `403`.
 
 ### CLI Options (all modes)
 
@@ -449,6 +453,8 @@ For more details, see the [official MCP documentation](https://modelcontextproto
 | `ANKI_CONNECT_API_KEY` | API key if configured in AnkiConnect | - |
 | `ANKI_CONNECT_TIMEOUT` | Request timeout in ms | `5000` |
 | `READ_ONLY` | Enable read-only mode (`true` or `1`) | `false` |
+| `ALLOWED_HOSTS` | HTTP mode: extra `Host` header values to accept beyond loopback (comma-separated hostnames). Required when binding to a LAN/public address or running behind a reverse proxy. See [HTTP Mode Configuration](#http-mode-configuration). | loopback only |
+| `ALLOWED_ORIGINS` | HTTP mode: comma-separated allowlist of browser `Origin`/`Referer` patterns (wildcards supported, e.g. `https://*.ngrok.io`). | `http://localhost:*,http://127.0.0.1:*,https://localhost:*,https://127.0.0.1:*` |
 | `TUNNEL_SERVER_URL` | Tunnel server WebSocket URL (tunnel mode only) | `wss://tunnel.ankimcp.ai` |
 | `MEDIA_ALLOWED_TYPES` | Extra MIME types to allow for file path imports (comma-separated, e.g., `application/pdf`) | - |
 | `MEDIA_IMPORT_DIR` | Restrict file path imports to this directory | - |
@@ -519,6 +525,14 @@ The media tools (`storeMediaFile`, `retrieveMediaFile`, `deleteMediaFile`) and `
 These protections apply to `storeMediaFile`, `retrieveMediaFile`, `deleteMediaFile`, and `updateNoteFields` audio/picture fields.
 
 > Path traversal vulnerability reported by [Hideaki Takahashi](https://github.com/Koukyosyumei).
+
+### DNS-Rebinding Protection (HTTP transport)
+
+When running in HTTP mode, the server validates the `Host` header on every request. By default only loopback hosts (`localhost`, `127.0.0.1`, `::1`) are accepted, regardless of port. `Host` is a browser-forbidden header, so a malicious web page cannot forge it — this closes the DNS-rebinding path where a rebound page reaches the local server with a spoofed `Host` and no `Origin`, and reaches the MCP tools. A disallowed `Host` is rejected with `403`.
+
+If you bind to `0.0.0.0`, run behind a reverse proxy, or expose a public tunnel domain, set `ALLOWED_HOSTS` (comma-separated hostnames) to permit those hosts. When tunneling with ngrok the server uses `--host-header=rewrite`, so the upstream still sees a loopback `Host`. See [HTTP Mode Configuration](#http-mode-configuration) for the full list of options.
+
+> DNS-rebinding vulnerability reported by [avishaigo-commits](https://github.com/avishaigo-commits) and [yotampe-pluto](https://github.com/yotampe-pluto).
 
 ## Privacy Policy
 
@@ -610,13 +624,26 @@ npm run build  # Builds once, creates dist/ with all three entry points
 **Environment Variables:**
 - `PORT` - HTTP server port (default: 3000)
 - `HOST` - Bind address (default: 127.0.0.1 for localhost-only)
-- `ALLOWED_ORIGINS` - Comma-separated list of allowed origins for CORS (default: localhost)
+- `ALLOWED_HOSTS` - Comma-separated extra `Host` header values to accept beyond the built-in loopback set (`localhost`, `127.0.0.1`, `::1`). Hostname-only and port-agnostic. Default: loopback only.
+- `ALLOWED_ORIGINS` - Comma-separated allowlist of browser `Origin`/`Referer` patterns; wildcards supported (e.g. `https://*.ngrok.io`). Default: `http://localhost:*,http://127.0.0.1:*,https://localhost:*,https://127.0.0.1:*`.
 - `LOG_LEVEL` - Logging level (default: info)
 
 **Security:**
-- Origin header validation (prevents DNS rebinding attacks)
-- Binds to localhost (127.0.0.1) by default
-- No authentication in current version (OAuth support planned)
+- **Host header validation (DNS-rebinding protection)** — every HTTP request must carry a `Host` header that matches the allowlist. By default only loopback hosts (`localhost`, `127.0.0.1`, `::1`) are accepted, regardless of port. `Host` is a browser-forbidden header, so a malicious web page cannot forge it — this closes the [DNS-rebinding](https://github.com/ankimcp/anki-mcp-server/security/advisories) path where a rebound page reaches the server with a spoofed `Host` and no `Origin`. A disallowed `Host` is rejected with `403`.
+- **Origin header validation** — browser requests with a present-but-disallowed `Origin`/`Referer` are rejected. Requests with **no** `Origin` (curl, Postman, MCP-over-HTTP clients) are allowed; Host validation is the defense against rebinding.
+- Binds to localhost (127.0.0.1) by default.
+- No authentication in current version (OAuth support planned).
+
+**Exposing HTTP mode beyond localhost** — if you bind to a LAN/public address or put the server behind a reverse proxy or public domain, you **must** set `ALLOWED_HOSTS` to the hostname(s) clients will use, otherwise every non-loopback request is rejected with `403`:
+
+```bash
+# Bind to all interfaces and accept the machine's LAN name + a public domain
+ALLOWED_HOSTS=my-nas.local,anki.example.com PORT=8080 HOST=0.0.0.0 node dist/main-http.js
+```
+
+When you bind to `0.0.0.0`/`::` without `ALLOWED_HOSTS`, the server logs a startup warning that only loopback `Host` headers will be accepted.
+
+> **Docker / reverse proxy / public domain:** the same rule applies. In Docker, requests usually arrive with the container's published hostname or the proxy's `Host`, so set `ALLOWED_HOSTS` accordingly. A reverse proxy (nginx, Caddy, Traefik) should either forward the original `Host` and have that hostname listed in `ALLOWED_HOSTS`, or rewrite the upstream `Host` to `localhost`. The built-in `--ngrok` integration handles this automatically (see below).
 
 **Example: Running Modes**
 ```bash

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "anki-mcp-server",
   "display_name": "Anki MCP Server",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "license": "MIT",
   "description": "Model Context Protocol server for Anki spaced repetition flashcard application",
   "long_description": "Transform your Anki experience with natural language interaction - like having a private tutor. This MCP server enables AI assistants to interact with Anki, allowing them to explain concepts, make learning more engaging, provide context, and adapt to your learning style. Features include review sessions, deck management, note creation and editing, and more.\n\nRequires Anki with the AnkiConnect plugin installed.",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ankimcp/anki-mcp-server",
   "mcpName": "ai.ankimcp/anki-mcp-server",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "Model Context Protocol server for Anki - enables AI assistants to interact with your Anki flashcards",
   "author": "Anatoly Tarnavsky",
   "private": false,

--- a/src/__tests__/app-config.service.spec.ts
+++ b/src/__tests__/app-config.service.spec.ts
@@ -7,6 +7,13 @@ describe("AppConfigService", () => {
     port: 3000,
     host: "127.0.0.1",
     nodeEnv: "development",
+    allowedHosts: [],
+    allowedOrigins: [
+      "http://localhost:*",
+      "http://127.0.0.1:*",
+      "https://localhost:*",
+      "https://127.0.0.1:*",
+    ],
     ankiConnect: {
       url: "http://localhost:8765",
       apiKey: undefined,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,9 @@
 import { DynamicModule, Module } from "@nestjs/common";
+import { APP_GUARD } from "@nestjs/core";
 import { ConfigModule } from "@nestjs/config";
 import { McpModule, McpTransportType } from "@rekog/mcp-nest";
+import { OriginValidationGuard } from "./http/guards/origin-validation.guard";
+import { HostValidationGuard } from "./http/guards/host-validation.guard";
 import {
   McpPrimitivesAnkiEssentialModule,
   ANKI_CONFIG,
@@ -150,6 +153,16 @@ export class AppModule {
           useValue: validatedConfig,
         },
         AppConfigService,
+        // DNS-rebinding protection (HTTP transport only). Registered at module
+        // level so the guards run for every request and can use DI for config.
+        {
+          provide: APP_GUARD,
+          useClass: OriginValidationGuard,
+        },
+        {
+          provide: APP_GUARD,
+          useClass: HostValidationGuard,
+        },
         ...ESSENTIAL_MCP_TOOLS,
         ...GUI_MCP_TOOLS,
       ],

--- a/src/config/__tests__/config.schema.spec.ts
+++ b/src/config/__tests__/config.schema.spec.ts
@@ -23,6 +23,8 @@ describe("Config Schema", () => {
         port: "8080",
         host: "0.0.0.0",
         nodeEnv: "production",
+        allowedHosts: undefined,
+        allowedOrigins: undefined,
         ankiConnect: {
           url: "http://anki.example.com:8765",
           apiKey: "test-key",
@@ -46,6 +48,8 @@ describe("Config Schema", () => {
         port: undefined,
         host: undefined,
         nodeEnv: undefined,
+        allowedHosts: undefined,
+        allowedOrigins: undefined,
         ankiConnect: {
           url: undefined,
           apiKey: undefined,
@@ -76,6 +80,13 @@ describe("Config Schema", () => {
           port: 3000,
           host: "127.0.0.1",
           nodeEnv: "development",
+          allowedHosts: [],
+          allowedOrigins: [
+            "http://localhost:*",
+            "http://127.0.0.1:*",
+            "https://localhost:*",
+            "https://127.0.0.1:*",
+          ],
           readOnly: false,
           ankiConnect: {
             url: "http://localhost:8765",

--- a/src/config/config.schema.ts
+++ b/src/config/config.schema.ts
@@ -4,11 +4,47 @@ import { z } from "zod";
  * Zod schema for application configuration
  * Maps environment variables to a strongly-typed config object
  */
+/**
+ * Default Origin patterns accepted when ALLOWED_ORIGINS is not set.
+ * Loopback-only; wildcards match any port. Previously hardcoded in the
+ * OriginValidationGuard, now sourced through config so it can be overridden.
+ */
+export const DEFAULT_ALLOWED_ORIGINS = [
+  "http://localhost:*",
+  "http://127.0.0.1:*",
+  "https://localhost:*",
+  "https://127.0.0.1:*",
+];
+
+/**
+ * Splits a comma-separated env string into a trimmed, non-empty list.
+ * Returns the schema default ([]) when the value is absent or blank.
+ */
+function parseCsvList(val: unknown): string[] | undefined {
+  if (val === undefined || val === null) return undefined;
+  if (Array.isArray(val)) return val;
+  if (typeof val !== "string") return undefined;
+  const items = val
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+  return items;
+}
+
 export const configSchema = z.object({
   // Server
   port: z.coerce.number().int().positive().default(3000),
   host: z.string().default("127.0.0.1"),
   nodeEnv: z.enum(["development", "production", "test"]).default("development"),
+
+  // DNS-rebinding protection (HTTP transport)
+  // Extra Host headers to accept beyond the built-in loopback set
+  // (localhost, 127.0.0.1, ::1). Hostname-only; ports are ignored.
+  allowedHosts: z.preprocess(parseCsvList, z.array(z.string())).default([]),
+  // Origin/Referer allowlist for the OriginValidationGuard.
+  allowedOrigins: z
+    .preprocess(parseCsvList, z.array(z.string()))
+    .default(DEFAULT_ALLOWED_ORIGINS),
 
   // AnkiConnect
   ankiConnect: z.object({
@@ -56,6 +92,8 @@ export function transformEnvToConfig(env: Record<string, any>): any {
     port: env.PORT,
     host: env.HOST,
     nodeEnv: env.NODE_ENV,
+    allowedHosts: env.ALLOWED_HOSTS,
+    allowedOrigins: env.ALLOWED_ORIGINS,
     ankiConnect: {
       url: env.ANKI_CONNECT_URL,
       apiKey: env.ANKI_CONNECT_API_KEY,

--- a/src/http/guards/__tests__/dns-rebinding.integration.spec.ts
+++ b/src/http/guards/__tests__/dns-rebinding.integration.spec.ts
@@ -1,0 +1,101 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication } from "@nestjs/common";
+import request from "supertest";
+import { AppModule } from "../../../app.module";
+import { buildConfigInput } from "../../../config";
+
+/**
+ * Integration tests for DNS-rebinding protection on the HTTP transport.
+ *
+ * Advisory: GHSA-j9xx-59ph-wmr6. Companion to the raw-socket e2e suite
+ * (test/e2e/dns-rebinding.http.e2e-spec.ts) — this tier boots the real
+ * `AppModule.forHttp()` in-process (no Docker, no Anki) and drives it with
+ * supertest, so it runs under `npm test`.
+ *
+ * The attack: a DNS-rebound browser sends a same-origin request whose Host is an
+ * attacker-controlled name (resolving to 127.0.0.1) with no Origin header. With
+ * no Host validation the server happily completes MCP `initialize` and dispatches
+ * tools.
+ *
+ * RED-UNTIL-FIX
+ * -------------
+ * The attacker-Host case is EXPECTED TO FAIL today: no Host guard runs, so the
+ * request is served (200). It turns GREEN once the Host-validation guard is
+ * registered.
+ *
+ * IMPORTANT — the fix must register the guard at the MODULE level (e.g. via an
+ * `APP_GUARD` provider in `AppModule.forHttp()`), not only via
+ * `app.useGlobalGuards(...)` in main-http.ts. `Test.createTestingModule` does not
+ * run main-http.ts's bootstrap, so a bootstrap-only guard would leave this test
+ * red forever. Module-level registration is the intended, testable design (and
+ * lets the guard use DI for config).
+ */
+describe("DNS-rebinding protection (HTTP module integration)", () => {
+  let app: INestApplication;
+
+  const ATTACKER_HOST = "attacker.example:3000";
+
+  const initializeBody = {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "dns-rebinding-test", version: "0.0.0" },
+    },
+  };
+
+  /** Statuses that count as "rejected before MCP dispatch" (see e2e spec). */
+  const REJECT_STATUSES = [403, 421];
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule.forHttp(buildConfigInput())],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it("positive control: a default (loopback) Host serves MCP initialize (200)", async () => {
+    // supertest's default Host is the ephemeral loopback address, which the
+    // allowlist must accept. This proves the endpoint serves initialize, so the
+    // attacker case getting 200 below is the vulnerability — not a dead endpoint.
+    const res = await request(app.getHttpServer())
+      .post("/")
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json, text/event-stream")
+      .send(initializeBody);
+
+    expect(res.status).toBe(200);
+  });
+
+  it("RED-UNTIL-FIX: initialize with an attacker Host is rejected", async () => {
+    const res = await request(app.getHttpServer())
+      .post("/")
+      .set("Host", ATTACKER_HOST)
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json, text/event-stream")
+      .send(initializeBody);
+
+    expect(REJECT_STATUSES).toContain(res.status);
+  });
+
+  it("RED-UNTIL-FIX: tools/list with an attacker Host is rejected before dispatch", async () => {
+    const res = await request(app.getHttpServer())
+      .post("/")
+      .set("Host", ATTACKER_HOST)
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json, text/event-stream")
+      .send({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+
+    expect(REJECT_STATUSES).toContain(res.status);
+  });
+});

--- a/src/http/guards/__tests__/dns-rebinding.integration.spec.ts
+++ b/src/http/guards/__tests__/dns-rebinding.integration.spec.ts
@@ -99,3 +99,54 @@ describe("DNS-rebinding protection (HTTP module integration)", () => {
     expect(REJECT_STATUSES).toContain(res.status);
   });
 });
+
+/**
+ * Escape-hatch coverage: setting ALLOWED_HOSTS must let an otherwise-blocked
+ * Host through end-to-end, proving the guard reads its allowlist from validated
+ * config. The env var is set before buildConfigInput() (which reads process.env)
+ * and restored in afterEach so it cannot leak into other suites.
+ */
+describe("DNS-rebinding protection — ALLOWED_HOSTS escape hatch (HTTP module integration)", () => {
+  let app: INestApplication;
+  const originalEnv = process.env;
+
+  const initializeBody = {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "dns-rebinding-test", version: "0.0.0" },
+    },
+  };
+
+  beforeEach(async () => {
+    process.env = { ...originalEnv, ALLOWED_HOSTS: "attacker.example" };
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule.forHttp(buildConfigInput())],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    process.env = originalEnv;
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it("serves MCP initialize for a Host now on the allowlist (200)", async () => {
+    const res = await request(app.getHttpServer())
+      .post("/")
+      .set("Host", "attacker.example:3000")
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json, text/event-stream")
+      .send(initializeBody);
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/http/guards/__tests__/host-validation.guard.spec.ts
+++ b/src/http/guards/__tests__/host-validation.guard.spec.ts
@@ -1,0 +1,146 @@
+import { ExecutionContext } from "@nestjs/common";
+import {
+  HostValidationGuard,
+  shouldWarnLoopbackOnly,
+} from "../host-validation.guard";
+import type { AppConfig } from "@/config";
+
+/**
+ * Unit tests for HostValidationGuard (DNS-rebinding protection, advisory
+ * GHSA-j9xx-59ph-wmr6) and the fail-closed startup-warning helper.
+ *
+ * The integration tier (dns-rebinding.integration.spec.ts) proves the guard is
+ * wired into AppModule.forHttp() and rejects/serves real requests. This tier
+ * exercises the matching logic directly against a fabricated ExecutionContext,
+ * mirroring origin-validation.guard.spec.ts.
+ */
+
+/**
+ * Builds a guard from a minimal AppConfig stub. Only `allowedHosts` is read by
+ * the constructor, so the rest of AppConfig is cast away — the same shape the
+ * APP_CONFIG provider supplies at runtime.
+ */
+function buildGuard(allowedHosts: string[] = []): HostValidationGuard {
+  return new HostValidationGuard({ allowedHosts } as AppConfig);
+}
+
+/**
+ * Fabricates an ExecutionContext exposing the given Host header. Passing
+ * `undefined` omits the header entirely (the absent-Host case).
+ */
+function createMockContext(host?: string): ExecutionContext {
+  const headers: Record<string, string> = {};
+  if (host !== undefined) headers.host = host;
+
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({ headers }),
+    }),
+  } as ExecutionContext;
+}
+
+describe("HostValidationGuard", () => {
+  describe("canActivate — loopback defaults (allow)", () => {
+    const allowed = [
+      "localhost",
+      "localhost:3000",
+      "LOCALHOST:8080",
+      "127.0.0.1",
+      "127.0.0.1:3000",
+      "::1",
+      "[::1]",
+      "[::1]:3000",
+    ];
+
+    it.each(allowed)("allows loopback Host %p", (host) => {
+      const guard = buildGuard();
+      expect(guard.canActivate(createMockContext(host))).toBe(true);
+    });
+  });
+
+  describe("canActivate — rebinding / edge forms (reject)", () => {
+    const rejected = [
+      "attacker.example",
+      "attacker.example:3000",
+      "localhost.", // trailing dot — not a loopback literal
+      "0:0:0:0:0:0:0:1", // expanded IPv6 loopback, not the ::1 literal
+      "[::ffff:127.0.0.1]", // IPv4-mapped IPv6 — not a literal match
+      "127.1", // shorthand IPv4 — not the dotted-quad literal
+      "2130706433", // decimal-encoded 127.0.0.1
+      "127.000.000.001", // zero-padded — not the literal
+      "localhost@evil.com", // userinfo trick
+      "example.com", // a normal external domain
+    ];
+
+    it.each(rejected)("rejects disallowed Host %p", (host) => {
+      const guard = buildGuard();
+      expect(guard.canActivate(createMockContext(host))).toBe(false);
+    });
+
+    it("rejects an absent Host header", () => {
+      const guard = buildGuard();
+      expect(guard.canActivate(createMockContext(undefined))).toBe(false);
+    });
+
+    it("rejects a blank Host header", () => {
+      const guard = buildGuard();
+      expect(guard.canActivate(createMockContext(""))).toBe(false);
+    });
+
+    it("rejects a whitespace-only Host header", () => {
+      const guard = buildGuard();
+      expect(guard.canActivate(createMockContext("   "))).toBe(false);
+    });
+  });
+
+  describe("canActivate — ALLOWED_HOSTS merge", () => {
+    const guard = buildGuard(["foo.local", "BAR.LOCAL:9000"]);
+
+    it("allows a configured host (port-stripped)", () => {
+      expect(guard.canActivate(createMockContext("foo.local"))).toBe(true);
+      expect(guard.canActivate(createMockContext("foo.local:1234"))).toBe(true);
+    });
+
+    it("allows a configured host case-folded and port-stripped", () => {
+      // Configured as "BAR.LOCAL:9000"; matches case-insensitively, any port.
+      expect(guard.canActivate(createMockContext("bar.local"))).toBe(true);
+      expect(guard.canActivate(createMockContext("bar.local:9000"))).toBe(true);
+    });
+
+    it("still allows the loopback defaults", () => {
+      expect(guard.canActivate(createMockContext("localhost"))).toBe(true);
+      expect(guard.canActivate(createMockContext("127.0.0.1:3000"))).toBe(true);
+      expect(guard.canActivate(createMockContext("[::1]"))).toBe(true);
+    });
+
+    it("still rejects a host not in the list", () => {
+      expect(guard.canActivate(createMockContext("attacker.example"))).toBe(
+        false,
+      );
+    });
+  });
+});
+
+describe("shouldWarnLoopbackOnly", () => {
+  it("returns false for a loopback bind with no allowed hosts", () => {
+    expect(shouldWarnLoopbackOnly("localhost", [])).toBe(false);
+    expect(shouldWarnLoopbackOnly("127.0.0.1", [])).toBe(false);
+    expect(shouldWarnLoopbackOnly("::1", [])).toBe(false);
+  });
+
+  it("returns true for 0.0.0.0 with no allowed hosts", () => {
+    expect(shouldWarnLoopbackOnly("0.0.0.0", [])).toBe(true);
+  });
+
+  it("returns false for 0.0.0.0 when allowed hosts are configured", () => {
+    expect(shouldWarnLoopbackOnly("0.0.0.0", ["my.host"])).toBe(false);
+  });
+
+  it("returns true for a concrete LAN bind with no allowed hosts (broadened check)", () => {
+    expect(shouldWarnLoopbackOnly("192.168.1.50", [])).toBe(true);
+  });
+
+  it("returns true for :: with no allowed hosts", () => {
+    expect(shouldWarnLoopbackOnly("::", [])).toBe(true);
+  });
+});

--- a/src/http/guards/__tests__/origin-validation.guard.spec.ts
+++ b/src/http/guards/__tests__/origin-validation.guard.spec.ts
@@ -1,4 +1,10 @@
 import { ExecutionContext } from "@nestjs/common";
+import {
+  configSchema,
+  transformEnvToConfig,
+  buildConfigInput,
+  type AppConfig,
+} from "@/config";
 
 // Mock Logger BEFORE importing OriginValidationGuard
 const mockLoggerWarn = jest.fn();
@@ -20,6 +26,17 @@ jest.mock("@nestjs/common", () => {
 });
 
 import { OriginValidationGuard } from "../origin-validation.guard";
+
+/**
+ * Builds a guard from the current process.env, exercising the same Zod config
+ * path the app uses (ALLOWED_ORIGINS -> validated config.allowedOrigins).
+ */
+function buildGuard(): OriginValidationGuard {
+  const config: AppConfig = configSchema.parse(
+    transformEnvToConfig(buildConfigInput()),
+  );
+  return new OriginValidationGuard(config);
+}
 
 describe("OriginValidationGuard", () => {
   let guard: OriginValidationGuard;
@@ -44,7 +61,7 @@ describe("OriginValidationGuard", () => {
 
   describe("constructor", () => {
     it("should use default allowed origins when ALLOWED_ORIGINS not set", () => {
-      guard = new OriginValidationGuard();
+      guard = buildGuard();
 
       // Test that default origins work
       const context = createMockContext("http://localhost:3000");
@@ -53,7 +70,7 @@ describe("OriginValidationGuard", () => {
 
     it("should use custom allowed origins from environment variable", () => {
       process.env.ALLOWED_ORIGINS = "https://example.com,https://test.com:8080";
-      guard = new OriginValidationGuard();
+      guard = buildGuard();
 
       const context = createMockContext("https://example.com");
       expect(guard.canActivate(context)).toBe(true);
@@ -61,7 +78,7 @@ describe("OriginValidationGuard", () => {
 
     it("should trim whitespace from allowed origins", () => {
       process.env.ALLOWED_ORIGINS = " https://example.com , https://test.com ";
-      guard = new OriginValidationGuard();
+      guard = buildGuard();
 
       const context = createMockContext("https://example.com");
       expect(guard.canActivate(context)).toBe(true);
@@ -70,7 +87,7 @@ describe("OriginValidationGuard", () => {
 
   describe("canActivate", () => {
     beforeEach(() => {
-      guard = new OriginValidationGuard();
+      guard = buildGuard();
     });
 
     it("should allow request with no origin header", () => {
@@ -107,7 +124,7 @@ describe("OriginValidationGuard", () => {
       // Note: Default pattern is 'http://localhost:*' which requires a port
       // 'http://localhost' (no port) won't match unless explicitly configured
       process.env.ALLOWED_ORIGINS = "http://localhost,http://localhost:*";
-      guard = new OriginValidationGuard();
+      guard = buildGuard();
 
       const context = createMockContext("http://localhost");
       expect(guard.canActivate(context)).toBe(true);
@@ -162,7 +179,7 @@ describe("OriginValidationGuard", () => {
 
     it("should allow ngrok origins when configured", () => {
       process.env.ALLOWED_ORIGINS = "https://*.ngrok.io";
-      guard = new OriginValidationGuard();
+      guard = buildGuard();
 
       const context1 = createMockContext("https://abc123.ngrok.io");
       const context2 = createMockContext("https://xyz789.ngrok.io");
@@ -173,7 +190,7 @@ describe("OriginValidationGuard", () => {
 
     it("should block non-matching ngrok subdomain", () => {
       process.env.ALLOWED_ORIGINS = "https://abc123.ngrok.io";
-      guard = new OriginValidationGuard();
+      guard = buildGuard();
 
       const context = createMockContext("https://xyz789.ngrok.io");
 
@@ -183,20 +200,20 @@ describe("OriginValidationGuard", () => {
 
   describe("matchesPattern", () => {
     beforeEach(() => {
-      guard = new OriginValidationGuard();
+      guard = buildGuard();
     });
 
     it("should match exact origin", () => {
       const context = createMockContext("https://example.com:3000");
       process.env.ALLOWED_ORIGINS = "https://example.com:3000";
-      guard = new OriginValidationGuard();
+      guard = buildGuard();
 
       expect(guard.canActivate(context)).toBe(true);
     });
 
     it("should match wildcard port pattern", () => {
       process.env.ALLOWED_ORIGINS = "https://example.com:*";
-      guard = new OriginValidationGuard();
+      guard = buildGuard();
 
       const context1 = createMockContext("https://example.com:3000");
       const context2 = createMockContext("https://example.com:8080");
@@ -207,7 +224,7 @@ describe("OriginValidationGuard", () => {
 
     it("should match wildcard subdomain pattern", () => {
       process.env.ALLOWED_ORIGINS = "https://*.example.com";
-      guard = new OriginValidationGuard();
+      guard = buildGuard();
 
       const context1 = createMockContext("https://api.example.com");
       const context2 = createMockContext("https://app.example.com");
@@ -218,7 +235,7 @@ describe("OriginValidationGuard", () => {
 
     it("should not match different protocol", () => {
       process.env.ALLOWED_ORIGINS = "http://localhost:*";
-      guard = new OriginValidationGuard();
+      guard = buildGuard();
 
       const context = createMockContext("https://localhost:3000");
 
@@ -227,7 +244,7 @@ describe("OriginValidationGuard", () => {
 
     it("should not match different host", () => {
       process.env.ALLOWED_ORIGINS = "http://localhost:*";
-      guard = new OriginValidationGuard();
+      guard = buildGuard();
 
       const context = createMockContext("http://example.com:3000");
 
@@ -236,7 +253,7 @@ describe("OriginValidationGuard", () => {
 
     it("should handle multiple wildcard patterns", () => {
       process.env.ALLOWED_ORIGINS = "https://*.ngrok.io,https://*.example.com";
-      guard = new OriginValidationGuard();
+      guard = buildGuard();
 
       const context1 = createMockContext("https://abc.ngrok.io");
       const context2 = createMockContext("https://app.example.com");
@@ -249,7 +266,7 @@ describe("OriginValidationGuard", () => {
 
     it("should escape dots in pattern correctly", () => {
       process.env.ALLOWED_ORIGINS = "https://app.example.com";
-      guard = new OriginValidationGuard();
+      guard = buildGuard();
 
       // Should not match 'app-example.com' or 'appaexampleacom'
       const context1 = createMockContext("https://app-example.com");
@@ -264,7 +281,7 @@ describe("OriginValidationGuard", () => {
 
   describe("security scenarios", () => {
     beforeEach(() => {
-      guard = new OriginValidationGuard();
+      guard = buildGuard();
     });
 
     it("should block DNS rebinding attack attempts", () => {

--- a/src/http/guards/host-validation.guard.ts
+++ b/src/http/guards/host-validation.guard.ts
@@ -1,0 +1,132 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  Inject,
+  Logger,
+} from "@nestjs/common";
+import { Request } from "express";
+import { APP_CONFIG, type AppConfig } from "@/config";
+
+/** Bind hosts that are loopback literals — Host validation is a no-op risk here. */
+const LOOPBACK_BIND_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+
+/**
+ * Decides whether to emit the fail-closed startup warning.
+ *
+ * The Host-validation guard only accepts loopback Host headers unless
+ * `ALLOWED_HOSTS` is set. So binding to any non-loopback address (`0.0.0.0`,
+ * `::`, or a concrete LAN/public IP like `192.168.1.50`) without configuring
+ * `ALLOWED_HOSTS` is a footgun: requests arriving via the machine's real
+ * hostname get 403'd. Warn in exactly that case.
+ *
+ * @param host         the bind host (`options.host`)
+ * @param allowedHosts the validated `config.allowedHosts` list
+ * @returns true when the bind host is non-loopback AND no extra hosts are allowed
+ */
+export function shouldWarnLoopbackOnly(
+  host: string,
+  allowedHosts: string[],
+): boolean {
+  const normalized = host.trim().toLowerCase();
+  const isLoopbackBind = LOOPBACK_BIND_HOSTS.has(normalized);
+  return !isLoopbackBind && allowedHosts.length === 0;
+}
+
+/**
+ * Host Validation Guard
+ *
+ * Validates the HTTP `Host` header to defend against DNS-rebinding attacks
+ * (advisory GHSA-j9xx-59ph-wmr6). A DNS-rebound browser issues a *same-origin*
+ * request — so the OriginValidationGuard's lenient absent-Origin path lets it
+ * through — but its Host header carries the attacker-controlled name. `Host` is
+ * a browser-forbidden header (scripts cannot forge it), so a strict Host
+ * allowlist fully closes the rebinding path while leaving non-browser clients
+ * (curl, MCP-over-HTTP) untouched as long as they target a loopback name.
+ *
+ * @see https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#security-warning
+ *
+ * Configuration:
+ * - Built-in allowlist: `localhost`, `127.0.0.1`, `::1` (always accepted).
+ * - `ALLOWED_HOSTS` env var (comma-separated) adds extra hostnames — required
+ *   when binding to 0.0.0.0 / a public domain / behind a reverse proxy.
+ * - Matching is hostname-only (port-agnostic) and case-insensitive.
+ */
+@Injectable()
+export class HostValidationGuard implements CanActivate {
+  private readonly logger = new Logger(HostValidationGuard.name);
+  private readonly allowedHosts: Set<string>;
+
+  /** Always-accepted loopback hostnames. */
+  private static readonly LOOPBACK_HOSTS = ["localhost", "127.0.0.1", "::1"];
+
+  constructor(@Inject(APP_CONFIG) config: AppConfig) {
+    this.allowedHosts = new Set(
+      [
+        ...HostValidationGuard.LOOPBACK_HOSTS,
+        ...config.allowedHosts.map((host) =>
+          HostValidationGuard.extractHostname(host),
+        ),
+      ].filter((host) => host.length > 0),
+    );
+  }
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<Request>();
+    const hostHeader = request.headers.host;
+
+    // A missing/blank Host header cannot be matched against the allowlist.
+    // Reject rather than guess — legitimate clients always send one.
+    if (!hostHeader || hostHeader.trim().length === 0) {
+      this.logger.warn(
+        "Rejected request with missing Host header (DNS-rebinding protection)",
+      );
+      return false;
+    }
+
+    const hostname = HostValidationGuard.extractHostname(hostHeader);
+
+    if (this.allowedHosts.has(hostname)) {
+      return true;
+    }
+
+    this.logger.warn(
+      `Rejected request with disallowed Host header: "${hostHeader}". ` +
+        `Allowed hosts are loopback by default; set ALLOWED_HOSTS ` +
+        `(comma-separated hostnames) to permit additional hosts.`,
+    );
+    return false;
+  }
+
+  /**
+   * Normalizes a Host value to a bare, lowercase hostname.
+   * Strips the port and IPv6 brackets so matching is port-agnostic:
+   *   `127.0.0.1:3000` -> `127.0.0.1`
+   *   `[::1]:3000`     -> `::1`
+   *   `Localhost`      -> `localhost`
+   */
+  private static extractHostname(value: string): string {
+    const trimmed = value.trim().toLowerCase();
+    if (trimmed.length === 0) {
+      return "";
+    }
+
+    // Bracketed IPv6 literal, with or without a port: [::1] / [::1]:3000
+    if (trimmed.startsWith("[")) {
+      const closing = trimmed.indexOf("]");
+      if (closing !== -1) {
+        return trimmed.slice(1, closing);
+      }
+    }
+
+    // For a bare IPv6 literal (multiple colons, no brackets) there is no port
+    // to strip — keep it as-is. Otherwise strip a single trailing `:port`.
+    const firstColon = trimmed.indexOf(":");
+    const lastColon = trimmed.lastIndexOf(":");
+    if (firstColon !== -1 && firstColon === lastColon) {
+      return trimmed.slice(0, firstColon);
+    }
+
+    return trimmed;
+  }
+}

--- a/src/http/guards/origin-validation.guard.ts
+++ b/src/http/guards/origin-validation.guard.ts
@@ -2,9 +2,11 @@ import {
   Injectable,
   CanActivate,
   ExecutionContext,
+  Inject,
   Logger,
 } from "@nestjs/common";
 import { Request } from "express";
+import { APP_CONFIG, type AppConfig } from "@/config";
 
 /**
  * Origin Validation Guard
@@ -18,17 +20,17 @@ import { Request } from "express";
  * - Set ALLOWED_ORIGINS environment variable (comma-separated list of patterns)
  * - Default: 'http://localhost:*,http://127.0.0.1:*,https://localhost:*,https://127.0.0.1:*'
  * - Supports wildcard patterns: 'http://localhost:*' matches any port
+ *
+ * The allowlist is sourced from validated config (`allowedOrigins`), which reads
+ * ALLOWED_ORIGINS through the Zod config pipeline.
  */
 @Injectable()
 export class OriginValidationGuard implements CanActivate {
   private readonly logger = new Logger(OriginValidationGuard.name);
   private readonly allowedOrigins: string[];
 
-  constructor() {
-    const defaultOrigins =
-      "http://localhost:*,http://127.0.0.1:*,https://localhost:*,https://127.0.0.1:*";
-    const originsEnv = process.env.ALLOWED_ORIGINS || defaultOrigins;
-    this.allowedOrigins = originsEnv.split(",").map((o) => o.trim());
+  constructor(@Inject(APP_CONFIG) config: AppConfig) {
+    this.allowedOrigins = config.allowedOrigins;
   }
 
   canActivate(context: ExecutionContext): boolean {

--- a/src/main-http.ts
+++ b/src/main-http.ts
@@ -1,11 +1,11 @@
 import { NestFactory } from "@nestjs/core";
+import { Logger } from "@nestjs/common";
 import { AppModule } from "./app.module";
 import {
   createPinoLogger,
   createLoggerService,
   LOG_DESTINATION,
 } from "./bootstrap";
-import { OriginValidationGuard } from "./http/guards/origin-validation.guard";
 import {
   parseCliArgs,
   parseOptionalUrl,
@@ -14,7 +14,8 @@ import {
 } from "./cli";
 import { createCli } from "@/cli";
 import { NgrokService } from "./services/ngrok.service";
-import { buildConfigInput } from "./config";
+import { buildConfigInput, configSchema, transformEnvToConfig } from "./config";
+import { shouldWarnLoopbackOnly } from "./http/guards/host-validation.guard";
 
 async function bootstrap() {
   // Check for updates (non-blocking, cached)
@@ -52,13 +53,29 @@ async function bootstrap() {
   const loggerService = createLoggerService(pinoLogger);
 
   // HTTP mode - create NestJS HTTP application
+  // Security guards (Origin + Host validation, required by the MCP Streamable
+  // HTTP spec) are registered at module level via APP_GUARD in forHttp().
   const app = await NestFactory.create(AppModule.forHttp(configInput), {
     logger: loggerService,
     bufferLogs: true,
   });
 
-  // Apply security guards (required by MCP Streamable HTTP spec)
-  app.useGlobalGuards(new OriginValidationGuard());
+  // Fail-closed warning: binding to a non-loopback address without an explicit
+  // ALLOWED_HOSTS means only loopback Host headers are accepted, so requests
+  // arriving via the machine's LAN/public hostname will be rejected. The
+  // emptiness check is sourced from the validated config (not raw process.env)
+  // so CLI overrides and Zod parsing are honored.
+  const validatedConfig = configSchema.parse(transformEnvToConfig(configInput));
+  const boundHost = options.host;
+  if (shouldWarnLoopbackOnly(boundHost, validatedConfig.allowedHosts)) {
+    new Logger("HttpBootstrap").warn(
+      `Server is bound to ${boundHost} but ALLOWED_HOSTS is not set. ` +
+        `For DNS-rebinding protection, only loopback Host headers ` +
+        `(localhost, 127.0.0.1, ::1) are accepted — requests via a LAN or ` +
+        `public hostname will be rejected with 403. Set ALLOWED_HOSTS ` +
+        `(comma-separated hostnames) to permit them.`,
+    );
+  }
 
   await app.listen(options.port, options.host);
 

--- a/src/services/ngrok.service.ts
+++ b/src/services/ngrok.service.ts
@@ -29,10 +29,18 @@ export class NgrokService {
       );
     }
 
-    // Start ngrok process
-    this.process = spawn("ngrok", ["http", port.toString()], {
-      stdio: "pipe", // Capture output for debugging if needed
-    });
+    // Start ngrok process.
+    // `--host-header=rewrite` makes ngrok rewrite the upstream Host header to the
+    // local target (localhost:<port>) so it passes the HostValidationGuard's
+    // loopback allowlist — without it ngrok forwards the public *.ngrok domain as
+    // the Host and the server rejects it (DNS-rebinding protection).
+    this.process = spawn(
+      "ngrok",
+      ["http", "--host-header=rewrite", port.toString()],
+      {
+        stdio: "pipe", // Capture output for debugging if needed
+      },
+    );
 
     // Register cleanup handlers (only once)
     if (!this.cleanupHandlersRegistered) {

--- a/test/e2e/dns-rebinding.http.e2e-spec.ts
+++ b/test/e2e/dns-rebinding.http.e2e-spec.ts
@@ -1,0 +1,222 @@
+/**
+ * E2E tests for DNS-rebinding protection on the HTTP transport.
+ *
+ * Advisory: GHSA-j9xx-59ph-wmr6 (mirrors the addon's tests/e2e/test_dns_rebinding.py).
+ *
+ * The CLI's HTTP listener (default 127.0.0.1:3000) performs NO Host-header
+ * validation, and its OriginValidationGuard intentionally allows requests that
+ * carry no Origin header (the curl/Postman path — see main-http.spec.ts). A
+ * DNS-rebound browser issuing *same-origin* requests (Host = an attacker name
+ * that resolves to 127.0.0.1, and no Origin header) therefore reaches MCP
+ * `initialize` / `tools/call` and can drive the local Anki collection.
+ *
+ * RED-UNTIL-FIX
+ * -------------
+ * The attacker-Host cases below are EXPECTED TO FAIL against the current server:
+ * with no Host guard the server returns 200 and serves MCP. They turn GREEN once
+ * the Host-validation guard is wired in (loopback allowlist + the ALLOWED_HOSTS
+ * escape hatch).
+ *
+ * The loopback cases (allowed / absent Origin -> 200) are regression guards that
+ * pass BOTH before and after the fix: they prove local browsers and non-browser
+ * clients (curl, MCP-over-HTTP) keep working.
+ *
+ * The present-but-disallowed-Origin case already passes today (the existing
+ * OriginValidationGuard rejects it) — it documents the half of the defense we
+ * already have, so it is NOT a red case.
+ *
+ * These use Node's `http` module — NOT the Inspector CLI used by the other e2e
+ * specs, which cannot set arbitrary Host/Origin headers — and parse SSE `data:`
+ * frames like the advisory PoC.
+ *
+ * Requires:
+ *   - HTTP server running: npm run start:prod:http  (initialize needs no Anki)
+ */
+import http from "node:http";
+import { URL } from "node:url";
+
+const SERVER_URL = process.env.MCP_SERVER_URL || "http://localhost:3000";
+const PARSED = new URL(SERVER_URL);
+const SERVER_HOST = PARSED.hostname || "localhost";
+const SERVER_PORT = Number(PARSED.port) || 3000;
+// Default config serves the MCP Streamable HTTP endpoint at root.
+const MCP_PATH = "/";
+
+// A loopback Host header the allowlist should accept.
+const LOOPBACK_HOST = `127.0.0.1:${SERVER_PORT}`;
+// An attacker-controlled name that (via rebinding) resolves to the loopback IP.
+const ATTACKER_HOST = `attacker.example:${SERVER_PORT}`;
+
+/**
+ * Statuses that count as "rejected before MCP dispatch".
+ *
+ * The CLI's guard returns 403 (consistent with the existing OriginValidationGuard
+ * and the MCP TypeScript SDK's own check). 421 ("Misdirected Request") is the more
+ * semantically specific code for a bad Host and is what the Python addon returns;
+ * we accept either so the test asserts the security outcome, not the exact code.
+ */
+const REJECT_STATUSES = [403, 421];
+
+interface McpResponse {
+  status: number;
+  body: unknown;
+}
+
+/** Build a JSON-RPC 2.0 request body. */
+function mcpBody(
+  method: string,
+  params?: Record<string, unknown>,
+  id = 1,
+): string {
+  const msg: Record<string, unknown> = { jsonrpc: "2.0", id, method };
+  if (params !== undefined) {
+    msg.params = params;
+  }
+  return JSON.stringify(msg);
+}
+
+/** Minimal MCP `initialize` params. */
+function initializeParams(): Record<string, unknown> {
+  return {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "dns-rebinding-test", version: "0.0.0" },
+  };
+}
+
+/**
+ * Parse a Streamable-HTTP response body (SSE `data:` frames or plain JSON).
+ * Returns the first decoded JSON-RPC object, or null if nothing parseable.
+ */
+function parseSseOrJson(raw: string): unknown {
+  if (!raw) {
+    return null;
+  }
+  if (raw.includes("data:")) {
+    const chunks = raw
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice("data:".length).trim());
+    for (const chunk of chunks) {
+      try {
+        return JSON.parse(chunk);
+      } catch {
+        // try next frame
+      }
+    }
+    return null;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Send a raw MCP POST with explicit Host/Origin headers.
+ *
+ * Connects to the real loopback IP:port (TCP) but sends `hostHeader` as the HTTP
+ * Host header — this simulates a DNS-rebound request whose Host points at an
+ * attacker-controlled name while the socket lands on the local server.
+ */
+function postMcp(opts: {
+  body: string;
+  hostHeader: string;
+  originHeader?: string;
+}): Promise<McpResponse> {
+  const { body, hostHeader, originHeader } = opts;
+  return new Promise((resolve, reject) => {
+    const headers: Record<string, string> = {
+      Host: hostHeader,
+      "Content-Type": "application/json",
+      // Streamable HTTP requires the client to accept both.
+      Accept: "application/json, text/event-stream",
+      "Content-Length": Buffer.byteLength(body).toString(),
+    };
+    if (originHeader !== undefined) {
+      headers.Origin = originHeader;
+    }
+
+    const req = http.request(
+      {
+        hostname: SERVER_HOST,
+        port: SERVER_PORT,
+        path: MCP_PATH,
+        method: "POST",
+        headers,
+        timeout: 30000,
+      },
+      (res) => {
+        let raw = "";
+        res.setEncoding("utf-8");
+        res.on("data", (chunk) => (raw += chunk));
+        res.on("end", () =>
+          resolve({ status: res.statusCode ?? 0, body: parseSseOrJson(raw) }),
+        );
+      },
+    );
+    req.on("error", reject);
+    req.on("timeout", () => req.destroy(new Error("request timed out")));
+    req.write(body);
+    req.end();
+  });
+}
+
+describe("E2E: DNS-rebinding protection (HTTP transport)", () => {
+  // Positive control: proves the endpoint actually serves `initialize` for a
+  // legitimate local request. If this passes but the attacker case below also
+  // gets 200, that 200 is the vulnerability — not a broken endpoint.
+  it("positive control: loopback Host serves MCP initialize (200 + result)", async () => {
+    const res = await postMcp({
+      body: mcpBody("initialize", initializeParams(), 1),
+      hostHeader: LOOPBACK_HOST,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ result: expect.anything() });
+  });
+
+  it("RED-UNTIL-FIX: initialize with an attacker Host is rejected", async () => {
+    const res = await postMcp({
+      body: mcpBody("initialize", initializeParams(), 2),
+      hostHeader: ATTACKER_HOST,
+    });
+    expect(REJECT_STATUSES).toContain(res.status);
+  });
+
+  it("RED-UNTIL-FIX: tools/call with an attacker Host is rejected before dispatch", async () => {
+    const res = await postMcp({
+      body: mcpBody("tools/call", { name: "listDecks", arguments: {} }, 3),
+      hostHeader: ATTACKER_HOST,
+    });
+    expect(REJECT_STATUSES).toContain(res.status);
+  });
+
+  it("regression: loopback Host with no Origin is still served (non-browser clients keep working)", async () => {
+    const res = await postMcp({
+      body: mcpBody("initialize", initializeParams(), 4),
+      hostHeader: LOOPBACK_HOST,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ result: expect.anything() });
+  });
+
+  it("regression: loopback Host + loopback Origin is served (200)", async () => {
+    const res = await postMcp({
+      body: mcpBody("initialize", initializeParams(), 5),
+      hostHeader: LOOPBACK_HOST,
+      originHeader: `http://127.0.0.1:${SERVER_PORT}`,
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("already-mitigated: loopback Host + disallowed Origin is rejected (existing OriginValidationGuard)", async () => {
+    // Documents the Origin half of the defense we already ship. Passes today.
+    const res = await postMcp({
+      body: mcpBody("initialize", initializeParams(), 6),
+      hostHeader: LOOPBACK_HOST,
+      originHeader: `http://attacker.example:${SERVER_PORT}`,
+    });
+    expect(REJECT_STATUSES).toContain(res.status);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the **DNS-rebinding** vector on the HTTP transport (advisory `GHSA-j9xx-59ph-wmr6`). A malicious web page could rebind its hostname to `127.0.0.1` and, from the victim's browser, reach the local MCP listener with a spoofed `Host` and **no `Origin`** — completing `initialize` → `tools/list` → `tools/call` against the local Anki collection. This was possible because the HTTP transport did **no Host-header validation**, and `OriginValidationGuard` intentionally allows requests with no `Origin` (the curl/Postman path).

`Host` is a browser-forbidden header (scripts can't forge it), so a strict Host allowlist fully closes the rebinding path while leaving non-browser clients untouched.

## What changed

- **New `HostValidationGuard`** — loopback-only Host allowlist (`localhost`, `127.0.0.1`, `::1`), **port-agnostic** and case-insensitive, extendable via `ALLOWED_HOSTS`. Missing/blank or disallowed `Host` → `403`, before MCP dispatch.
- **Guards now wired at module level** via `APP_GUARD` in `forHttp()` (DI-injectable); dropped the manual `useGlobalGuards`. **stdio/tunnel untouched** (no local HTTP socket → not applicable).
- **Config**: `ALLOWED_ORIGINS` moved into validated config; added `ALLOWED_HOSTS` / `ALLOWED_ORIGINS` to the Zod schema. `OriginValidationGuard` behavior is unchanged (absent-Origin still lenient).
- **Fail-closed** on non-loopback binds (`0.0.0.0`/LAN) with an actionable startup warning when `ALLOWED_HOSTS` is unset.
- **ngrok**: spawns with `--host-header=rewrite` so the upstream sees a loopback `Host` and passes the allowlist (ngrok's default is byte-for-byte pass-through of the public domain).
- **Docs**: README Security + HTTP Mode Configuration sections; reporters credited.

## Backward compatibility

| Consumer | Result |
|---|---|
| STDIO (Claude Desktop/MCPB, Cursor, etc.) | unaffected — no HTTP socket |
| Tunnel mode | unaffected — no local HTTP socket |
| Localhost browser / curl / Postman (no Origin) | works (loopback Host allowed; absent-Origin still lenient) |
| ngrok | works via `--host-header=rewrite` |
| Docker `0.0.0.0` / reverse proxy / public domain | **must set `ALLOWED_HOSTS`** (fail-closed by design) |

## Test plan (TDD)

Red tests committed first (`21a498d`), then the fix (`4af2f00`):
- `src/http/guards/__tests__/dns-rebinding.integration.spec.ts` — boots `AppModule.forHttp()` + supertest; attacker Host → rejected, loopback → 200, `ALLOWED_HOSTS` escape hatch admits a non-loopback host.
- `src/http/guards/__tests__/host-validation.guard.spec.ts` — table-driven `extractHostname`/allow-reject matrix (IPv6 forms, port stripping, case, trailing dot, `localhost@evil`, blank/absent Host, `ALLOWED_HOSTS` merge).
- `test/e2e/dns-rebinding.http.e2e-spec.ts` — raw-socket PoC against the running server.

Full suite green locally via the pre-push hook: **71 suites / 1223 tests**.

## Credits

DNS-rebinding vulnerability reported by [@avishaigo-commits](https://github.com/avishaigo-commits) and [@yotampe-pluto](https://github.com/yotampe-pluto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)