### PR TITLE
feat(review-stats): support collection-wide analysis when deck is omitted

### DIFF
--- a/src/mcp/primitives/essential/tools/review-stats/__tests__/review-stats.tool.spec.ts
+++ b/src/mcp/primitives/essential/tools/review-stats/__tests__/review-stats.tool.spec.ts
@@ -743,4 +743,149 @@ describe("ReviewStatsTool", () => {
       expect(result.error).toContain("failed to fetch reviews");
     });
   });
+
+  describe("all decks (no deck filter)", () => {
+    it("should aggregate reviews across the whole collection when deck is omitted", async () => {
+      // Arrange
+      const startDate = "2026-01-10";
+      const endDate = "2026-01-11";
+      const startTs = new Date(startDate).getTime();
+
+      ankiClient.invoke.mockImplementation((action: string, params?: any) => {
+        if (action === "cardReviews") {
+          throw new Error(
+            "cardReviews must not be called for the all-decks path",
+          );
+        }
+        if (action === "findCards") {
+          expect(params?.query).toBe("deck:*");
+          return Promise.resolve([101, 202]);
+        }
+        if (action === "getReviewsOfCards") {
+          expect(params?.cards).toEqual([101, 202]);
+          // getReviewsOfCards returns objects keyed by card id.
+          // `ease` is the button pressed (1-4), `factor` is the ease factor.
+          return Promise.resolve({
+            "101": [
+              {
+                id: startTs + 1000,
+                usn: -1,
+                ease: 3,
+                ivl: 4,
+                lastIvl: -60,
+                factor: 2500,
+                time: 6000,
+                type: 0,
+              }, // good, day 1
+              {
+                id: startTs + 2000,
+                usn: -1,
+                ease: 1,
+                ivl: 4,
+                lastIvl: -60,
+                factor: 2500,
+                time: 6000,
+                type: 0,
+              }, // again, day 1
+              {
+                id: startTs - 999999,
+                usn: -1,
+                ease: 3,
+                ivl: 4,
+                lastIvl: -60,
+                factor: 2500,
+                time: 6000,
+                type: 0,
+              }, // before window -> dropped
+            ],
+            "202": [
+              {
+                id: startTs + 86400000 + 1000,
+                usn: -1,
+                ease: 3,
+                ivl: 4,
+                lastIvl: -60,
+                factor: 2500,
+                time: 6000,
+                type: 0,
+              }, // good, day 2
+            ],
+          });
+        }
+        return Promise.resolve({});
+      });
+
+      // Act
+      const rawResult = await tool.execute({
+        start_date: startDate,
+        end_date: endDate,
+      });
+      const result = parseToolResult(rawResult) as ReviewStatsResult;
+
+      // Assert
+      expect(result.deck).toBe("All Decks");
+      expect(result.reviews_by_day).toEqual([
+        { date: "2026-01-10", count: 2 },
+        { date: "2026-01-11", count: 1 },
+      ]);
+      expect(result.summary.total_reviews).toBe(3); // pre-window review dropped
+      expect(result.retention.by_rating).toEqual({
+        again: 1,
+        hard: 0,
+        good: 2,
+        easy: 0,
+      });
+      expect(ankiClient.invoke).toHaveBeenCalledWith("findCards", {
+        query: "deck:*",
+      });
+      expect(ankiClient.invoke).toHaveBeenCalledWith("getReviewsOfCards", {
+        cards: [101, 202],
+      });
+    });
+
+    it("should treat an empty-string deck as all decks", async () => {
+      // Arrange
+      const startDate = "2026-01-10";
+
+      ankiClient.invoke.mockImplementation((action: string) => {
+        if (action === "cardReviews") {
+          throw new Error(
+            "cardReviews must not be called for the all-decks path",
+          );
+        }
+        if (action === "findCards") return Promise.resolve([]);
+        return Promise.resolve({});
+      });
+
+      // Act
+      const rawResult = await tool.execute({ deck: "", start_date: startDate });
+      const result = parseToolResult(rawResult) as ReviewStatsResult;
+
+      // Assert
+      expect(result.deck).toBe("All Decks");
+      expect(result.reviews_by_day).toEqual([]);
+      expect(result.summary.total_reviews).toBe(0);
+    });
+
+    it("should return empty stats when the collection has no cards", async () => {
+      // Arrange
+      const startDate = "2026-01-10";
+
+      ankiClient.invoke.mockImplementation((action: string) => {
+        if (action === "findCards") return Promise.resolve([]);
+        if (action === "getReviewsOfCards") {
+          throw new Error("should not fetch reviews when there are no cards");
+        }
+        return Promise.resolve({});
+      });
+
+      // Act
+      const rawResult = await tool.execute({ start_date: startDate });
+      const result = parseToolResult(rawResult) as ReviewStatsResult;
+
+      // Assert
+      expect(result.summary.total_reviews).toBe(0);
+      expect(result.retention.overall).toBe(0);
+    });
+  });
 });

--- a/src/mcp/primitives/essential/tools/review-stats/review-stats.tool.ts
+++ b/src/mcp/primitives/essential/tools/review-stats/review-stats.tool.ts
@@ -4,7 +4,11 @@ import { z } from "zod";
 import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
 import { createErrorResponse } from "@/mcp/utils/anki.utils";
 import { computeRetention, calculateStreak } from "@/mcp/utils/stats.utils";
-import { ReviewStatsResult, CardReviewTuple } from "./review-stats.types";
+import {
+  ReviewStatsResult,
+  CardReviewTuple,
+  CardReviewObject,
+} from "./review-stats.types";
 
 /** Milliseconds in one day */
 const MS_PER_DAY = 86400000;
@@ -23,13 +27,16 @@ export class ReviewStatsTool {
     description:
       "Get review history analysis including temporal patterns, retention metrics, and study streak information. " +
       "Use this to analyze learning progress over time, identify review patterns, and track consistency. " +
-      "Requires a start date and deck name; end date defaults to today.",
+      "Requires a start date; the deck is optional - omit it to analyze the entire collection (all decks). " +
+      "End date defaults to today.",
     parameters: z
       .object({
         deck: z
           .string()
+          .optional()
           .describe(
-            "Deck name to filter reviews (REQUIRED - AnkiConnect API requires a deck)",
+            "Deck name to filter reviews. Matches the exact deck only (subdecks are NOT rolled up). " +
+              "Omit to analyze the entire collection (all decks).",
           ),
         start_date: z
           .string()
@@ -107,16 +114,19 @@ export class ReviewStatsTool {
     },
   })
   async execute(params: {
-    deck: string;
+    deck?: string;
     start_date: string;
     end_date?: string;
   }) {
     try {
-      const { deck, start_date } = params;
+      const { start_date } = params;
+      const deck =
+        params.deck && params.deck.length > 0 ? params.deck : undefined;
+      const deckLabel = deck ?? "All Decks";
       const end_date = params.end_date || this.getTodayISO();
 
       this.logger.log(
-        `Getting review statistics from ${start_date} to ${end_date} for deck: ${deck}`,
+        `Getting review statistics from ${start_date} to ${end_date} for deck: ${deckLabel}`,
       );
 
       // Convert dates to timestamps (in milliseconds)
@@ -124,18 +134,23 @@ export class ReviewStatsTool {
       const startTimestamp = new Date(start_date).getTime();
       const endTimestamp = new Date(end_date).getTime() + MS_PER_DAY; // Add 1 day to include end date
 
-      // Step 1: Get detailed review data for the specified deck
-      this.logger.log(`Fetching detailed review data for deck: ${deck}...`);
-
-      const reviews = await this.ankiClient.invoke<CardReviewTuple[]>(
-        "cardReviews",
-        {
-          startID: startTimestamp,
-          deck: deck,
-        },
+      // Step 1: Get detailed review data.
+      // A specific deck uses AnkiConnect's `cardReviews` (exact deck, no subdeck
+      // rollup). When no deck is given we fall back to a collection-wide path,
+      // because `cardReviews` requires an exact deck name and can't answer
+      // "all decks".
+      this.logger.log(
+        `Fetching detailed review data for deck: ${deckLabel}...`,
       );
 
-      // Filter reviews to end_date (API only filters by start)
+      const reviews = deck
+        ? await this.ankiClient.invoke<CardReviewTuple[]>("cardReviews", {
+            startID: startTimestamp,
+            deck,
+          })
+        : await this.fetchCollectionReviews(startTimestamp);
+
+      // Filter reviews to end_date (lower bound already applied above)
       const filteredReviews = reviews.filter(
         (review) => review[0] <= endTimestamp,
       );
@@ -188,7 +203,7 @@ export class ReviewStatsTool {
           start: start_date,
           end: end_date,
         },
-        deck: deck,
+        deck: deckLabel,
         reviews_by_day: reviewsByDay,
         summary: {
           total_reviews: totalReviews,
@@ -214,6 +229,59 @@ export class ReviewStatsTool {
         hint: "Make sure Anki is running and date format is YYYY-MM-DD. Use listDecks to verify deck name if filtering by deck.",
       });
     }
+  }
+
+  /**
+   * Fetch reviews across the entire collection (all decks).
+   *
+   * AnkiConnect's `cardReviews` action requires an exact deck name and does not
+   * roll up subdecks, so it can't answer the "all decks" case. Instead we list
+   * every card (`findCards deck:*`) and pull their review logs in one batch
+   * (`getReviewsOfCards`), then normalize each entry to the same
+   * `CardReviewTuple` layout the per-deck path produces so the downstream
+   * aggregation is identical. Reviews older than `startTimestamp` are dropped
+   * here to mirror cardReviews' `startID` lower-bound filtering.
+   */
+  private async fetchCollectionReviews(
+    startTimestamp: number,
+  ): Promise<CardReviewTuple[]> {
+    const cardIds = await this.ankiClient.invoke<number[]>("findCards", {
+      query: "deck:*",
+    });
+
+    if (cardIds.length === 0) {
+      return [];
+    }
+
+    const reviewsByCard = await this.ankiClient.invoke<
+      Record<string, CardReviewObject[]>
+    >("getReviewsOfCards", { cards: cardIds });
+
+    const tuples: CardReviewTuple[] = [];
+    for (const [cardId, cardReviews] of Object.entries(reviewsByCard)) {
+      const cid = Number(cardId);
+      for (const r of cardReviews) {
+        if (r.id < startTimestamp) {
+          continue;
+        }
+        // Map getReviewsOfCards object -> cardReviews tuple layout.
+        // tuple[3] is the button pressed (r.ease); tuple[6] is the ease factor
+        // (r.factor).
+        tuples.push([
+          r.id,
+          cid,
+          r.usn,
+          r.ease,
+          r.ivl,
+          r.lastIvl,
+          r.factor,
+          r.time,
+          r.type,
+        ]);
+      }
+    }
+
+    return tuples;
   }
 
   /**

--- a/src/mcp/primitives/essential/tools/review-stats/review-stats.types.ts
+++ b/src/mcp/primitives/essential/tools/review-stats/review-stats.types.ts
@@ -25,6 +25,26 @@ export interface CardReviewsParams {
 }
 
 /**
+ * Single review entry returned by AnkiConnect getReviewsOfCards API.
+ * Keys mirror the revlog columns. Note: `ease` is the button pressed (1-4),
+ * while `factor` is the ease factor (e.g. 2500) - the opposite naming from the
+ * cardReviews tuple, where index 3 is the button and index 6 is the factor.
+ */
+export interface CardReviewObject {
+  /** Review timestamp in milliseconds (revlog id) */
+  id: number;
+  usn: number;
+  /** Button pressed: 1=Again, 2=Hard, 3=Good, 4=Easy */
+  ease: number;
+  ivl: number;
+  lastIvl: number;
+  /** Ease factor (e.g. 2500) */
+  factor: number;
+  time: number;
+  type: number;
+}
+
+/**
  * Card review tuple returned by AnkiConnect cardReviews API
  * Format: [timestamp, cardId, usn, buttonPressed, newInterval, previousInterval, ease, timeTaken, reviewType]
  */

--- a/test/e2e/stats-tools.e2e-spec.ts
+++ b/test/e2e/stats-tools.e2e-spec.ts
@@ -425,16 +425,17 @@ describe("E2E: Stats Tools (STDIO)", () => {
       expect(daysDiff).toBeLessThan(2); // Allow for timezone differences
     });
 
-    it("should require deck parameter", () => {
-      // deck is required for review_stats due to AnkiConnect API limitation
+    it("should aggregate all decks when deck is omitted", () => {
+      // Omitting deck rolls the whole collection up under "All Decks"
       const startDate = new Date();
       startDate.setDate(startDate.getDate() - 7);
 
-      expect(() => {
-        callTool("review_stats", {
-          start_date: startDate.toISOString().split("T")[0],
-        });
-      }).toThrow(/deck|required|invalid/i);
+      const result = callTool("review_stats", {
+        start_date: startDate.toISOString().split("T")[0],
+      });
+
+      expect(result.deck).toBe("All Decks");
+      expect(Array.isArray(result.reviews_by_day)).toBe(true);
     });
   });
 

--- a/test/e2e/stats-tools.http.e2e-spec.ts
+++ b/test/e2e/stats-tools.http.e2e-spec.ts
@@ -431,8 +431,8 @@ describe("E2E: Stats Tools (HTTP Streamable)", () => {
       expect(daysDiff).toBeLessThan(2); // Allow for timezone differences
     });
 
-    it("should require deck parameter", () => {
-      // Validation errors return a response with error text instead of throwing
+    it("should aggregate all decks when deck is omitted", () => {
+      // Omitting deck rolls the whole collection up under "All Decks"
       const startDate = new Date();
       startDate.setDate(startDate.getDate() - 7);
 
@@ -440,8 +440,8 @@ describe("E2E: Stats Tools (HTTP Streamable)", () => {
         start_date: startDate.toISOString().split("T")[0],
       });
 
-      const text = result.text as string;
-      expect(text).toMatch(/deck|required|invalid/i);
+      expect(result.deck).toBe("All Decks");
+      expect(Array.isArray(result.reviews_by_day)).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

`review_stats` currently requires a `deck` and matches only the **exact** deck. AnkiConnect's `cardReviews` action needs an exact deck name and does not roll up subdecks, so the behaviour already documented in the code - `ReviewStatsParams.deck?` *"omit for entire collection"*, the `"All Decks"` result label, and the `getNumCardsReviewedByDay`-as-collection-path hint in the existing test - never actually worked: omitting the deck (or passing a parent deck) returned empty results.

This PR finishes that documented behaviour.

## What changed

- `deck` is now **optional**. The per-deck path is unchanged (same single `cardReviews` call, same output).
- When `deck` is omitted or empty, reviews are aggregated across the **whole collection** via `findCards("deck:*")` + `getReviewsOfCards`, then normalised into the same `CardReviewTuple` shape the per-deck path produces - so `reviews_by_day`, `retention`, and `streak` are computed by the exact same downstream code.
- Reviews older than `start_date` are dropped in the collection path to mirror `cardReviews`' `startID` lower-bound filtering.
- The result `deck` field is labelled `"All Decks"` for the collection case.

## Why `findCards` + `getReviewsOfCards` (not `getNumCardsReviewedByDay`)

`getNumCardsReviewedByDay` returns only per-day counts, which would leave `retention`/`by_rating` empty for the all-decks case. Using `getReviewsOfCards` keeps the output identical and complete for both paths (counts **and** retention), at the cost of one extra call (`findCards` then a single batched `getReviewsOfCards`).

## Tests

Added unit tests for the collection path:
- cross-deck aggregation with the lower-bound window filter,
- empty-string deck treated as all decks,
- empty collection.

All existing `review-stats` tests pass unchanged (the per-deck path is untouched). Verified end-to-end against a live Anki: `review_stats` with no deck returns `"All Decks"` with per-day counts matching `getNumCardsReviewedByDay`, plus retention.

> Note: two unrelated suites (`store-media-file`, `tunnel/credentials`) fail in my local Windows environment on `main` as well (filesystem/credential-store specifics) - they are independent of this change.
