### PR TITLE
feat(tunnel): identify CLI to tunnel server on WS handshake

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "anki-mcp-server",
   "display_name": "Anki MCP Server",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "license": "MIT",
   "description": "Model Context Protocol server for Anki spaced repetition flashcard application",
   "long_description": "Transform your Anki experience with natural language interaction - like having a private tutor. This MCP server enables AI assistants to interact with Anki, allowing them to explain concepts, make learning more engaging, provide context, and adapt to your learning style. Features include review sessions, deck management, note creation and editing, and more.\n\nRequires Anki with the AnkiConnect plugin installed.",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ankimcp/anki-mcp-server",
   "mcpName": "ai.ankimcp/anki-mcp-server",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Model Context Protocol server for Anki - enables AI assistants to interact with your Anki flashcards",
   "author": "Anatoly Tarnavsky",
   "private": false,

--- a/src/tunnel/__tests__/tunnel.client.spec.ts
+++ b/src/tunnel/__tests__/tunnel.client.spec.ts
@@ -132,6 +132,10 @@ describe("TunnelClient", () => {
         expect.objectContaining({
           headers: {
             Authorization: "Bearer mock_access_token",
+            "x-ankimcp-client-type": "cli",
+            "x-ankimcp-client-version": expect.stringMatching(
+              /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/,
+            ),
           },
         }),
       );
@@ -249,7 +253,9 @@ describe("TunnelClient", () => {
       expect(WebSocket).toHaveBeenCalledWith(
         TEST_TUNNEL_URL,
         expect.objectContaining({
-          headers: { Authorization: "Bearer caller_supplied_token" },
+          headers: expect.objectContaining({
+            Authorization: "Bearer caller_supplied_token",
+          }),
         }),
       );
     });

--- a/src/tunnel/tunnel.client.ts
+++ b/src/tunnel/tunnel.client.ts
@@ -15,6 +15,7 @@ import {
 } from "./tunnel.protocol";
 import { CredentialsService, TunnelCredentials } from "./credentials.service";
 import { DeviceFlowService, DeviceFlowError } from "./device-flow.service";
+import { getVersion } from "../version";
 
 /**
  * Handler interface for processing incoming MCP requests
@@ -218,10 +219,15 @@ export class TunnelClient extends EventEmitter {
 
       this.logger.log(`Connecting to tunnel server: ${url}`);
 
-      // Create WebSocket with Authorization header
+      // Create WebSocket with Authorization header + client identification.
+      // The tunnel server strictly validates these and silently falls back to
+      // "unknown client" on anything invalid, so they're safe against older
+      // servers too — send unconditionally, no feature gating.
       this.ws = new WebSocket(url, {
         headers: {
           Authorization: `Bearer ${this.credentials.access_token}`,
+          "x-ankimcp-client-type": "cli",
+          "x-ankimcp-client-version": getVersion(),
         },
       });
 


### PR DESCRIPTION
## Summary

Adds two optional headers to the tunnel WebSocket upgrade so the tunnel server can identify the connecting client and surface it in the user dashboard, admin panel, and Prometheus metrics.

- `x-ankimcp-client-type: cli` — literal lowercase `cli`
- `x-ankimcp-client-version: <version>` — sourced from `version.ts` (reads `package.json`), **not hardcoded**

Headers are sent in `establishConnection()` in `src/tunnel/tunnel.client.ts`.

## Design notes

- **Sent unconditionally** — no feature detection or version gating. The server strictly validates these and silently falls back to "unknown client" on anything invalid, so the change is safe against both old and new tunnel servers.
- **Version resolved at connect time** via `getVersion()`, so the header always reflects the running build.

## Testing

- Updated two existing assertions in `tunnel.client.spec.ts` that compared the `headers` object exactly; the primary connection test now asserts all three headers, with the version validated against the server's own regex (`/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/`).
- Full suite green: **1241 tests, 71 suites**.
- Version bumped 0.22.1 → 0.22.2.

## Verify

Connect against a server running the new tunnel service — the dashboard connection card should read `cli v<version> · since <time>` instead of "unknown client".

🤖 Generated with [Claude Code](https://claude.com/claude-code)