### PR TITLE
fix(review): render card front/back per card template, not note fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ The server exposes **42 MCP tools** — 31 essential tools for everyday Anki ope
 - `present_card` - Show a card for review with its question/front side
 - `rate_card` - Rate card performance (Again, Hard, Good, Easy) and schedule the next review
 
+> **Note:** Card `front`/`back` content is rendered per card from its own template (as Anki shows it), so reversed and cloze cards display the correct direction. Static text added by your card templates appears in the output as well.
+
 #### Deck Management
 - `listDecks` - List all decks, optionally with per-deck card-count statistics
 - `deckStats` - Get comprehensive statistics for a single deck (counts, ease/interval distributions)

--- a/src/mcp/primitives/essential/tools/__tests__/get-cards.tool.spec.ts
+++ b/src/mcp/primitives/essential/tools/__tests__/get-cards.tool.spec.ts
@@ -299,6 +299,39 @@ describe("GetCardsTool", () => {
       });
     });
 
+    it("renders each card of a multi-card note per its template ordinal", async () => {
+      // A "Basic (and reversed card)" note yields two cards. The forward card
+      // (ord 0) renders Front->Back; the reversed card (ord 1) renders
+      // Back->Front. Field-based extraction returned identical content for both;
+      // per-card rendering (question/answer) must not.
+      const sharedFields = {
+        Front: { value: "こんにちは", order: 0 },
+        Back: { value: "Hello", order: 1 },
+      };
+      const reversedPair: AnkiCard[] = [
+        { ...mockCards.reversedForward, fields: sharedFields },
+        { ...mockCards.reversedBackward, fields: sharedFields },
+      ];
+
+      ankiClient.invoke
+        .mockResolvedValueOnce(reversedPair.map((c) => c.cardId))
+        .mockResolvedValueOnce(reversedPair);
+
+      const result = parseToolResult(await tool.getCards({}));
+
+      expect(result.success).toBe(true);
+      expect(result.cards[0]).toMatchObject({
+        front: "こんにちは",
+        back: "Hello",
+      });
+      // The reversed card must show the OPPOSITE direction, not a duplicate.
+      expect(result.cards[1]).toMatchObject({
+        front: "Hello",
+        back: "こんにちは",
+      });
+      expect(result.cards[1].front).not.toBe(result.cards[0].front);
+    });
+
     it("should report progress correctly", async () => {
       // Arrange
       ankiClient.invoke

--- a/src/mcp/primitives/essential/tools/__tests__/get-due-cards.tool.spec.ts
+++ b/src/mcp/primitives/essential/tools/__tests__/get-due-cards.tool.spec.ts
@@ -280,6 +280,39 @@ describe("GetDueCardsTool", () => {
       });
     });
 
+    it("renders each card of a multi-card note per its template ordinal", async () => {
+      // A "Basic (and reversed card)" note yields two cards. The forward card
+      // (ord 0) renders Front->Back; the reversed card (ord 1) renders
+      // Back->Front. Field-based extraction returned identical content for both;
+      // per-card rendering (question/answer) must not.
+      const sharedFields = {
+        Front: { value: "こんにちは", order: 0 },
+        Back: { value: "Hello", order: 1 },
+      };
+      const reversedPair: AnkiCard[] = [
+        { ...mockCards.reversedForward, fields: sharedFields },
+        { ...mockCards.reversedBackward, fields: sharedFields },
+      ];
+
+      ankiClient.invoke
+        .mockResolvedValueOnce(reversedPair.map((c) => c.cardId))
+        .mockResolvedValueOnce(reversedPair);
+
+      const result = parseToolResult(await tool.getDueCards({}));
+
+      expect(result.success).toBe(true);
+      expect(result.cards[0]).toMatchObject({
+        front: "こんにちは",
+        back: "Hello",
+      });
+      // The reversed card must show the OPPOSITE direction, not a duplicate.
+      expect(result.cards[1]).toMatchObject({
+        front: "Hello",
+        back: "こんにちは",
+      });
+      expect(result.cards[1].front).not.toBe(result.cards[0].front);
+    });
+
     it("should report progress correctly", async () => {
       // Arrange
       ankiClient.invoke

--- a/src/mcp/primitives/essential/tools/__tests__/present-card.tool.spec.ts
+++ b/src/mcp/primitives/essential/tools/__tests__/present-card.tool.spec.ts
@@ -1,0 +1,115 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { PresentCardTool } from "../present-card.tool";
+import { AnkiConnectClient } from "../../../../clients/anki-connect.client";
+import { mockCards } from "../../../../../test-fixtures/mock-data";
+import { parseToolResult } from "../../../../../test-fixtures/test-helpers";
+import { AnkiCard } from "../../../../types/anki.types";
+
+// Mock the AnkiConnectClient
+jest.mock("../../../../clients/anki-connect.client");
+
+describe("PresentCardTool", () => {
+  let tool: PresentCardTool;
+  let ankiClient: jest.Mocked<AnkiConnectClient>;
+
+  const sharedFields = {
+    Front: { value: "こんにちは", order: 0 },
+    Back: { value: "Hello", order: 1 },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PresentCardTool, AnkiConnectClient],
+    }).compile();
+
+    tool = module.get<PresentCardTool>(PresentCardTool);
+    ankiClient = module.get(
+      AnkiConnectClient,
+    ) as jest.Mocked<AnkiConnectClient>;
+
+    jest.clearAllMocks();
+  });
+
+  describe("presentCard", () => {
+    it("returns the question only when show_answer is false", async () => {
+      const card: AnkiCard = {
+        ...mockCards.dueCard,
+        fields: {
+          Front: { value: "¿Cómo estás?", order: 0 },
+          Back: { value: "How are you?", order: 1 },
+        },
+      };
+      ankiClient.invoke.mockResolvedValueOnce([card]);
+
+      const result = parseToolResult(
+        await tool.presentCard({ card_id: card.cardId, show_answer: false }),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.card.front).toBe("¿Cómo estás?");
+      expect(result.card.back).toBeUndefined();
+      expect(result.instruction).toContain("Question shown");
+    });
+
+    it("splits the rendered answer on the <hr id=answer> marker", async () => {
+      const card: AnkiCard = {
+        ...mockCards.dueCard,
+        fields: {
+          Front: { value: "¿Cómo estás?", order: 0 },
+          Back: { value: "How are you?", order: 1 },
+        },
+      };
+      ankiClient.invoke.mockResolvedValueOnce([card]);
+
+      const result = parseToolResult(
+        await tool.presentCard({ card_id: card.cardId, show_answer: true }),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.card.front).toBe("¿Cómo estás?");
+      // Back must not duplicate the front (which the raw answer embeds).
+      expect(result.card.back).toBe("How are you?");
+      expect(result.instruction).toContain("Answer revealed");
+    });
+
+    it("renders the reversed card of a multi-card note per its ordinal", async () => {
+      const reversed: AnkiCard = {
+        ...mockCards.reversedBackward,
+        fields: sharedFields,
+      };
+      ankiClient.invoke.mockResolvedValueOnce([reversed]);
+
+      const result = parseToolResult(
+        await tool.presentCard({ card_id: reversed.cardId, show_answer: true }),
+      );
+
+      expect(result.success).toBe(true);
+      // ord 1 renders Back->Front: question is the English side.
+      expect(result.card.front).toBe("Hello");
+      expect(result.card.back).toBe("こんにちは");
+    });
+
+    it("returns an error when the card is not found", async () => {
+      ankiClient.invoke.mockResolvedValueOnce([]);
+
+      const result = parseToolResult(
+        await tool.presentCard({ card_id: 999, show_answer: false }),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("not found");
+      expect(result.cardId).toBe(999);
+    });
+
+    it("handles AnkiConnect errors gracefully", async () => {
+      ankiClient.invoke.mockRejectedValueOnce(new Error("fetch failed"));
+
+      const result = parseToolResult(
+        await tool.presentCard({ card_id: 123, show_answer: false }),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("fetch failed");
+    });
+  });
+});

--- a/src/mcp/primitives/essential/tools/get-cards.tool.ts
+++ b/src/mcp/primitives/essential/tools/get-cards.tool.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
 import { AnkiCard, SimplifiedCard } from "@/mcp/types/anki.types";
 import {
-  extractCardContent,
+  extractRenderedCardContent,
   createErrorResponse,
 } from "@/mcp/utils/anki.utils";
 
@@ -134,12 +134,12 @@ export class GetCardsTool {
 
       // Transform cards to simplified structure
       const cards: SimplifiedCard[] = cardsInfo.map((card) => {
-        const { front, back } = extractCardContent(card.fields);
+        const { front, back } = extractRenderedCardContent(card);
 
         return {
           cardId: card.cardId,
-          front: front || card.question || "",
-          back: back || card.answer || "",
+          front,
+          back,
           deckName: card.deckName,
           modelName: card.modelName,
           due: card.due || 0,

--- a/src/mcp/primitives/essential/tools/get-due-cards.tool.ts
+++ b/src/mcp/primitives/essential/tools/get-due-cards.tool.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
 import { AnkiCard, SimplifiedCard } from "@/mcp/types/anki.types";
 import {
-  extractCardContent,
+  extractRenderedCardContent,
   createErrorResponse,
 } from "@/mcp/utils/anki.utils";
 
@@ -158,12 +158,12 @@ export class GetDueCardsTool {
 
       // Transform cards to simplified structure
       const dueCards: SimplifiedCard[] = cardsInfo.map((card) => {
-        const { front, back } = extractCardContent(card.fields);
+        const { front, back } = extractRenderedCardContent(card);
 
         return {
           cardId: card.cardId,
-          front: front || card.question || "",
-          back: back || card.answer || "",
+          front,
+          back,
           deckName: card.deckName,
           modelName: card.modelName,
           due: card.due || 0,

--- a/src/mcp/primitives/essential/tools/present-card.tool.ts
+++ b/src/mcp/primitives/essential/tools/present-card.tool.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
 import { AnkiCard, CardPresentation } from "@/mcp/types/anki.types";
 import {
-  extractCardContent,
+  extractRenderedCardContent,
   getCardType,
   createErrorResponse,
 } from "@/mcp/utils/anki.utils";
@@ -82,13 +82,13 @@ export class PresentCardTool {
       }
 
       const card = cardsInfo[0];
-      const { front, back } = extractCardContent(card.fields);
+      const { front, back } = extractRenderedCardContent(card);
       const cardType = getCardType(card.type);
 
       // Build the presentation object
       const presentation: CardPresentation = {
         cardId: card.cardId,
-        front: front || card.question || "",
+        front,
         deckName: card.deckName,
         modelName: card.modelName,
         tags: card.tags || [],
@@ -102,7 +102,7 @@ export class PresentCardTool {
 
       // Only include answer if requested
       if (showAnswer) {
-        presentation.back = back || card.answer || "";
+        presentation.back = back;
       }
 
       this.logger.log(`Retrieved card ${card_id} for presentation`);

--- a/src/mcp/utils/__tests__/anki.utils.spec.ts
+++ b/src/mcp/utils/__tests__/anki.utils.spec.ts
@@ -1,0 +1,149 @@
+import { cleanHtml, extractRenderedCardContent } from "../anki.utils";
+
+describe("cleanHtml", () => {
+  it("returns an empty string for empty input", () => {
+    expect(cleanHtml("")).toBe("");
+  });
+
+  it("strips plain HTML tags", () => {
+    expect(cleanHtml("<b>Bold</b> and <i>italic</i>")).toBe("Bold and italic");
+  });
+
+  it("removes <style> blocks including their contents", () => {
+    expect(cleanHtml("<style>.card { color: red; }</style>Answer text")).toBe(
+      "Answer text",
+    );
+  });
+
+  it("removes <script> blocks including their contents", () => {
+    expect(cleanHtml('<script>alert("x")</script>Answer text')).toBe(
+      "Answer text",
+    );
+  });
+
+  it("converts <br> and block-closing tags to newlines", () => {
+    expect(cleanHtml("Line 1<br>Line 2")).toBe("Line 1\nLine 2");
+    expect(cleanHtml("Line 1<br/>Line 2")).toBe("Line 1\nLine 2");
+    expect(cleanHtml("<div>Line 1</div><div>Line 2</div>")).toBe(
+      "Line 1\nLine 2",
+    );
+    expect(cleanHtml("<p>Para 1</p><p>Para 2</p>")).toBe("Para 1\nPara 2");
+  });
+
+  it("decodes common HTML entities", () => {
+    expect(
+      cleanHtml("Tom &amp; Jerry &lt;3 &gt; &quot;q&quot; &#39;s&#39;"),
+    ).toBe("Tom & Jerry <3 > \"q\" 's'");
+    expect(cleanHtml("a&nbsp;b")).toBe("a b");
+  });
+
+  it("decodes &amp; last so double-encoded entities are preserved", () => {
+    expect(cleanHtml("&amp;lt;")).toBe("&lt;");
+    expect(cleanHtml("&amp;amp;")).toBe("&amp;");
+  });
+
+  it("collapses excess whitespace and blank lines", () => {
+    expect(cleanHtml("a   \t  b")).toBe("a b");
+    expect(cleanHtml("a<br><br><br>b")).toBe("a\nb");
+  });
+
+  it("preserves Anki media markers and cloze-rendered text", () => {
+    expect(cleanHtml("Listen: [sound:hello.mp3]")).toBe(
+      "Listen: [sound:hello.mp3]",
+    );
+    expect(cleanHtml('<span class="cloze">[...]</span>')).toBe("[...]");
+  });
+});
+
+describe("extractRenderedCardContent", () => {
+  it("extracts front and back for a forward card", () => {
+    const result = extractRenderedCardContent({
+      question: "¿Cómo estás?",
+      answer: "¿Cómo estás?\n\n<hr id=answer>\n\nHow are you?",
+    });
+    expect(result).toEqual({ front: "¿Cómo estás?", back: "How are you?" });
+  });
+
+  it("extracts reversed direction for the reversed card of the same note", () => {
+    const result = extractRenderedCardContent({
+      question: "Hello",
+      answer: "Hello\n\n<hr id=answer>\n\nこんにちは",
+    });
+    expect(result).toEqual({ front: "Hello", back: "こんにちは" });
+  });
+
+  it("keeps only the part after the <hr id=answer> marker", () => {
+    const result = extractRenderedCardContent({
+      question: "Front",
+      answer: "Front<hr id=answer>Back only",
+    });
+    expect(result.back).toBe("Back only");
+  });
+
+  it("matches quoted and self-closing separator variants", () => {
+    expect(
+      extractRenderedCardContent({
+        question: "Q",
+        answer: 'Q<hr id="answer">Back',
+      }).back,
+    ).toBe("Back");
+    expect(
+      extractRenderedCardContent({
+        question: "Q",
+        answer: "Q<hr id='answer'>Back",
+      }).back,
+    ).toBe("Back");
+    expect(
+      extractRenderedCardContent({
+        question: "Q",
+        answer: "Q<hr id=answer />Back",
+      }).back,
+    ).toBe("Back");
+  });
+
+  it("matches id=answer regardless of position among other attributes", () => {
+    expect(
+      extractRenderedCardContent({
+        question: "Q",
+        answer: 'Q<hr class="sep" id=answer>Back',
+      }).back,
+    ).toBe("Back");
+    expect(
+      extractRenderedCardContent({
+        question: "Q",
+        answer: 'Q<hr id="answer" class="foo">Back',
+      }).back,
+    ).toBe("Back");
+  });
+
+  it("uses the whole answer when no separator is present", () => {
+    const result = extractRenderedCardContent({
+      question: "Q",
+      answer: "Just the back",
+    });
+    expect(result.back).toBe("Just the back");
+  });
+
+  it("strips <style>/<script> blocks embedded in rendered output", () => {
+    const result = extractRenderedCardContent({
+      question: "<style>.card{}</style>Question",
+      answer: "Question<hr id=answer><script>x()</script>Answer",
+    });
+    expect(result).toEqual({ front: "Question", back: "Answer" });
+  });
+
+  it("decodes entities in rendered content", () => {
+    const result = extractRenderedCardContent({
+      question: "Salt &amp; Pepper",
+      answer: "Salt &amp; Pepper<hr id=answer>Se&nbsp;sal",
+    });
+    expect(result).toEqual({ front: "Salt & Pepper", back: "Se sal" });
+  });
+
+  it("handles empty question and answer", () => {
+    expect(extractRenderedCardContent({ question: "", answer: "" })).toEqual({
+      front: "",
+      back: "",
+    });
+  });
+});

--- a/src/mcp/utils/anki.utils.ts
+++ b/src/mcp/utils/anki.utils.ts
@@ -7,71 +7,82 @@ import { AnkiCard, CardRating, CardType } from "../types/anki.types";
 import { AnkiConnectError } from "../clients/anki-connect.client";
 
 /**
- * Helper function to clean HTML from card content
+ * Matches Anki's answer separator that most back templates emit right after
+ * `{{FrontSide}}`. Matches any `<hr>` carrying an `id=answer` attribute
+ * regardless of quoting (`id=answer`, `id="answer"`, `id='answer'`) or where the
+ * attribute sits among others (e.g. `<hr class="sep" id=answer>`). Bounded by
+ * `[^>]*` so it stays linear (no catastrophic backtracking).
+ */
+const ANSWER_SEPARATOR_REGEX = /<hr\b[^>]*\bid=["']?answer["']?[^>]*>/i;
+
+/**
+ * Clean rendered card HTML down to readable plain text.
+ *
+ * Strips `<style>`/`<script>` blocks (including their contents, which rendered
+ * cards can embed), converts line-break/block tags to newlines, removes the
+ * remaining tags, decodes common HTML entities, and collapses excess
+ * whitespace. Anki media markers like `[sound:...]` and cloze-rendered text are
+ * left untouched.
  */
 export function cleanHtml(html: string): string {
-  return html
-    .replace(/<[^>]*>/g, "") // Remove HTML tags
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/\n\s*\n/g, "\n") // Remove extra newlines
-    .trim();
+  if (!html) {
+    return "";
+  }
+
+  return (
+    html
+      // Drop <style>/<script> blocks entirely — their inner text is not content.
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "")
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "")
+      // Convert line-break and block-closing tags to newlines.
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<\/(?:div|p)>/gi, "\n")
+      // Remove all remaining tags. (Runs before entity decoding so that decoded
+      // "<"/">" can't be mistaken for real tags.)
+      .replace(/<[^>]*>/g, "")
+      // Decode common HTML entities. `&amp;` is resolved LAST so double-encoded
+      // input like `&amp;lt;` stays `&lt;` instead of chaining into `<`.
+      .replace(/&nbsp;/g, " ")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/&amp;/g, "&")
+      // Collapse excess whitespace while preserving intentional line breaks.
+      .replace(/[ \t]+/g, " ")
+      .replace(/ *\n */g, "\n")
+      .replace(/\n{2,}/g, "\n")
+      .trim()
+  );
 }
 
 /**
- * Extract front and back content from Anki card fields
+ * Extract front and back text from a card's *rendered* output.
+ *
+ * Unlike field-based extraction, this uses AnkiConnect's per-card `question`
+ * and `answer` HTML (from `cardsInfo`), so it honors the card's template
+ * ordinal — reversed, cloze, and custom-template cards all render correctly.
+ *
+ * The rendered answer normally begins with the question (via `{{FrontSide}}`)
+ * followed by `<hr id=answer>`. When that marker is present we keep only the
+ * part after it so the back isn't a duplicate of the front; otherwise the whole
+ * cleaned answer is used.
  */
-export function extractCardContent(fields: AnkiCard["fields"]): {
-  front: string;
-  back: string;
-} {
-  let front = "";
-  let back = "";
+export function extractRenderedCardContent(
+  card: Pick<AnkiCard, "question" | "answer">,
+): { front: string; back: string } {
+  const question = card.question ?? "";
+  const answer = card.answer ?? "";
 
-  if (!fields) {
-    return { front, back };
-  }
-
-  // Common field names for different note types
-  const frontFieldNames = ["Front", "正面", "Question", "Text"];
-  const backFieldNames = ["Back", "背面", "Answer", "Extra", "Back Extra"];
-
-  // Find front field
-  for (const fieldName of frontFieldNames) {
-    if (fields[fieldName]) {
-      front = fields[fieldName].value;
-      break;
-    }
-  }
-
-  // Find back field
-  for (const fieldName of backFieldNames) {
-    if (fields[fieldName]) {
-      back = fields[fieldName].value;
-      break;
-    }
-  }
-
-  // Fallback to first two fields if standard names not found
-  if (!front && !back) {
-    const fieldEntries = Object.entries(fields).sort(
-      (a, b) => a[1].order - b[1].order,
-    );
-    if (fieldEntries.length > 0) {
-      front = fieldEntries[0][1].value;
-    }
-    if (fieldEntries.length > 1) {
-      back = fieldEntries[1][1].value;
-    }
-  }
+  const separatorMatch = answer.match(ANSWER_SEPARATOR_REGEX);
+  const backHtml =
+    separatorMatch && separatorMatch.index !== undefined
+      ? answer.slice(separatorMatch.index + separatorMatch[0].length)
+      : answer;
 
   return {
-    front: cleanHtml(front),
-    back: cleanHtml(back),
+    front: cleanHtml(question),
+    back: cleanHtml(backHtml),
   };
 }
 

--- a/src/test-fixtures/mock-data.ts
+++ b/src/test-fixtures/mock-data.ts
@@ -60,13 +60,16 @@ export const mockDecks = {
   names: ["Default", "Spanish", "Japanese::JLPT N5", "French::Beginner"],
 };
 
+// `question`/`answer` mirror what AnkiConnect's `cardsInfo` returns: rendered,
+// per-card HTML. Answers start with the question (via `{{FrontSide}}`) then the
+// `<hr id=answer>` separator, so front/back extraction must split on the marker.
 export const mockCards = {
   dueCard: {
     cardId: 1502298033754,
     noteId: 1502298033753,
     deckName: "Spanish",
     question: "¿Cómo estás?",
-    answer: "How are you?",
+    answer: "¿Cómo estás?\n\n<hr id=answer>\n\nHow are you?",
     due: 1,
     interval: 1,
     factor: 2500,
@@ -85,7 +88,7 @@ export const mockCards = {
     noteId: 1502298033757,
     deckName: "Japanese::JLPT N5",
     question: "こんにちは",
-    answer: "Hello",
+    answer: "こんにちは\n\n<hr id=answer>\n\nHello",
     due: 0,
     interval: 0,
     factor: 2500,
@@ -96,6 +99,48 @@ export const mockCards = {
     modelName: "Basic (and reversed card)",
     fieldOrder: 0,
     ord: 0,
+    css: "",
+    note: 1502298033757,
+  },
+  // Two cards produced by a SINGLE "Basic (and reversed card)" note. They share
+  // the same fields but render in opposite directions per their template
+  // ordinal — the reason field-based extraction is wrong and per-card rendering
+  // (question/answer) is required.
+  reversedForward: {
+    cardId: 1502298033758,
+    noteId: 1502298033757,
+    deckName: "Japanese::JLPT N5",
+    question: "こんにちは",
+    answer: "こんにちは\n\n<hr id=answer>\n\nHello",
+    due: 1,
+    interval: 1,
+    factor: 2500,
+    reviews: 2,
+    lapses: 0,
+    type: 2,
+    queue: 2,
+    modelName: "Basic (and reversed card)",
+    fieldOrder: 0,
+    ord: 0,
+    css: "",
+    note: 1502298033757,
+  },
+  reversedBackward: {
+    cardId: 1502298033759,
+    noteId: 1502298033757,
+    deckName: "Japanese::JLPT N5",
+    question: "Hello",
+    answer: "Hello\n\n<hr id=answer>\n\nこんにちは",
+    due: 1,
+    interval: 1,
+    factor: 2500,
+    reviews: 2,
+    lapses: 0,
+    type: 2,
+    queue: 2,
+    modelName: "Basic (and reversed card)",
+    fieldOrder: 1,
+    ord: 1,
     css: "",
     note: 1502298033757,
   },


### PR DESCRIPTION
## Problem

`get_cards`, `get_due_cards`, and `present_card` derived each card's `front`/`back` from **note-level field values** (`extractCardContent`), which are identical for every card of a note. For a note generating multiple cards — e.g. *Basic (and reversed card)* — the reversed card (ord 1) was returned showing the forward direction. Cloze and custom templates were also rendered incorrectly, since the card's template ordinal was never consulted.

Reported by Liquidmantis (via OpenCode + the npm CLI): both cards of a reversible note came back as `front: "¿A qué te dedicas?" / back: "What do you do (for a living)?"`.

## Fix

Use AnkiConnect's per-card rendered `question`/`answer` from `cardsInfo`, which honors each card's template ordinal:

- New `extractRenderedCardContent(card)` in `anki.utils.ts`: `front` = cleaned `question`; `back` = cleaned `answer` split on Anki's `<hr id=answer>` marker (tolerant regex, attributes in any position) to drop the `{{FrontSide}}` duplication. If no marker is present, the whole cleaned answer is used.
- `cleanHtml()` strengthened: strips `<style>`/`<script>` blocks including contents, converts `<br>`/`</div>`/`</p>` to newlines, decodes entities (`&amp;` last, avoiding double-decode), collapses whitespace. Dependency-free.
- All three tools switched to the new helper; dead `front || card.question` fallback removed; obsolete `extractCardContent` deleted.
- README: note that front/back is per-card template rendering.

## Behavior change (release-notes worthy)

`front`/`back` content changes for **all** cards, not just reversed ones: output is now the true template rendering, so static text added by card templates appears in the output. Reversed and cloze cards now show the correct direction — which is the point.

Anki media markers (`[sound:...]`, `[anki:play:q:0]`) pass through as-is (documented behavior, kept intentionally).

## Testing

- New unit specs for `cleanHtml` / `extractRenderedCardContent` (marker variants, entity decoding, style/script stripping, empty inputs).
- Regression tests in all three tool specs: two cards of one note (ord 0 / ord 1) must render opposite directions — verified these fail under the old implementation.
- New `present_card` spec; `mock-data.ts` and `review-session` workflow mocks updated with realistic rendered HTML.
- `npm run type-check` clean, `npm run lint` 0 errors, full suite 1264/1264 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)