### PR TITLE
fix(security): harden media-URL SSRF guard against IPv6 transition bypass (v0.22.5)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "anki-mcp-server",
   "display_name": "Anki MCP Server",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "license": "MIT",
   "description": "Model Context Protocol server for Anki spaced repetition flashcard application",
   "long_description": "Transform your Anki experience with natural language interaction - like having a private tutor. This MCP server enables AI assistants to interact with Anki, allowing them to explain concepts, make learning more engaging, provide context, and adapt to your learning style. Features include review sessions, deck management, note creation and editing, and more.\n\nRequires Anki with the AnkiConnect plugin installed.",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ankimcp/anki-mcp-server",
   "mcpName": "ai.ankimcp/anki-mcp-server",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "description": "Model Context Protocol server for Anki - enables AI assistants to interact with your Anki flashcards",
   "author": "Anatoly Tarnavsky",
   "private": false,

--- a/src/mcp/primitives/essential/tools/__tests__/store-media-file.tool.spec.ts
+++ b/src/mcp/primitives/essential/tools/__tests__/store-media-file.tool.spec.ts
@@ -17,8 +17,13 @@ jest.mock("node:dns", () => {
   };
 });
 
-const mockLookup = dns.promises.lookup as jest.MockedFunction<
-  typeof dns.promises.lookup
+// Cast to the `{ all: true }` overload of dns.promises.lookup, which the
+// implementation uses (returns LookupAddress[] instead of a single address)
+const mockLookup = dns.promises.lookup as unknown as jest.MockedFunction<
+  (
+    hostname: string,
+    options: dns.LookupAllOptions,
+  ) => Promise<dns.LookupAddress[]>
 >;
 
 describe("StoreMediaFileTool", () => {
@@ -35,17 +40,11 @@ describe("StoreMediaFileTool", () => {
       AnkiConnectClient,
     ) as jest.Mocked<AnkiConnectClient>;
 
-    mockLookup.mockResolvedValue({
-      address: "93.184.216.34",
-      family: 4,
-    } as any);
+    mockLookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
 
     jest.clearAllMocks();
 
-    mockLookup.mockResolvedValue({
-      address: "93.184.216.34",
-      family: 4,
-    } as any);
+    mockLookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
   });
 
   it("should store media file with base64 data", async () => {
@@ -277,10 +276,9 @@ describe("StoreMediaFileTool", () => {
       });
 
       it("should reject URLs resolving to private IPs", async () => {
-        mockLookup.mockResolvedValueOnce({
-          address: "192.168.1.100",
-          family: 4,
-        } as any);
+        mockLookup.mockResolvedValueOnce([
+          { address: "192.168.1.100", family: 4 },
+        ]);
 
         const params = {
           filename: "internal.mp3",
@@ -298,10 +296,9 @@ describe("StoreMediaFileTool", () => {
       });
 
       it("should allow URLs resolving to public IPs", async () => {
-        mockLookup.mockResolvedValueOnce({
-          address: "93.184.216.34",
-          family: 4,
-        } as any);
+        mockLookup.mockResolvedValueOnce([
+          { address: "93.184.216.34", family: 4 },
+        ]);
 
         const params = {
           filename: "public.mp3",
@@ -322,10 +319,9 @@ describe("StoreMediaFileTool", () => {
       it("should respect MEDIA_ALLOWED_HOSTS env var", async () => {
         const originalEnv = process.env.MEDIA_ALLOWED_HOSTS;
         try {
-          mockLookup.mockResolvedValue({
-            address: "192.168.1.100",
-            family: 4,
-          } as any);
+          mockLookup.mockResolvedValue([
+            { address: "192.168.1.100", family: 4 },
+          ]);
 
           const params = {
             filename: "internal.mp3",
@@ -387,10 +383,9 @@ describe("StoreMediaFileTool", () => {
 
     describe("cloud metadata protection", () => {
       it("blocks cloud metadata endpoint (169.254.169.254)", async () => {
-        mockLookup.mockResolvedValue({
-          address: "169.254.169.254",
-          family: 4,
-        } as any);
+        mockLookup.mockResolvedValue([
+          { address: "169.254.169.254", family: 4 },
+        ]);
 
         const result = await tool.execute({
           filename: "metadata.txt",

--- a/src/mcp/primitives/essential/tools/__tests__/update-note-fields.tool.spec.ts
+++ b/src/mcp/primitives/essential/tools/__tests__/update-note-fields.tool.spec.ts
@@ -22,8 +22,13 @@ jest.mock("node:dns", () => {
   };
 });
 
-const mockLookup = dns.promises.lookup as jest.MockedFunction<
-  typeof dns.promises.lookup
+// Cast to the `{ all: true }` overload of dns.promises.lookup, which the
+// implementation uses (returns LookupAddress[] instead of a single address)
+const mockLookup = dns.promises.lookup as unknown as jest.MockedFunction<
+  (
+    hostname: string,
+    options: dns.LookupAllOptions,
+  ) => Promise<dns.LookupAddress[]>
 >;
 
 describe("UpdateNoteFieldsTool", () => {
@@ -43,10 +48,7 @@ describe("UpdateNoteFieldsTool", () => {
     jest.clearAllMocks();
 
     // Default: resolve to a public IP so non-security tests aren't affected
-    mockLookup.mockResolvedValue({
-      address: "93.184.216.34",
-      family: 4,
-    } as any);
+    mockLookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
   });
 
   describe("updateNoteFields", () => {
@@ -390,10 +392,9 @@ describe("UpdateNoteFieldsTool", () => {
       });
 
       it("should reject private IP URLs in audio[].url", async () => {
-        mockLookup.mockResolvedValueOnce({
-          address: "192.168.1.50",
-          family: 4,
-        } as any);
+        mockLookup.mockResolvedValueOnce([
+          { address: "192.168.1.50", family: 4 },
+        ]);
 
         const rawResult = await tool.updateNoteFields({
           note: {
@@ -418,10 +419,9 @@ describe("UpdateNoteFieldsTool", () => {
       });
 
       it("should allow public URLs in audio[].url", async () => {
-        mockLookup.mockResolvedValueOnce({
-          address: "93.184.216.34",
-          family: 4,
-        } as any);
+        mockLookup.mockResolvedValueOnce([
+          { address: "93.184.216.34", family: 4 },
+        ]);
 
         ankiClient.invoke
           .mockResolvedValueOnce([mockNotes.spanish]) // notesInfo
@@ -449,8 +449,8 @@ describe("UpdateNoteFieldsTool", () => {
       it("rejects if any audio URL in array is malicious", async () => {
         // First lookup returns public IP, second returns private
         mockLookup
-          .mockResolvedValueOnce({ address: "93.184.216.34", family: 4 })
-          .mockResolvedValueOnce({ address: "192.168.1.1", family: 4 });
+          .mockResolvedValueOnce([{ address: "93.184.216.34", family: 4 }])
+          .mockResolvedValueOnce([{ address: "192.168.1.1", family: 4 }]);
 
         const result = await tool.updateNoteFields({
           note: {
@@ -502,10 +502,7 @@ describe("UpdateNoteFieldsTool", () => {
       });
 
       it("should reject private IP URLs in picture[].url", async () => {
-        mockLookup.mockResolvedValueOnce({
-          address: "10.0.0.1",
-          family: 4,
-        } as any);
+        mockLookup.mockResolvedValueOnce([{ address: "10.0.0.1", family: 4 }]);
 
         const rawResult = await tool.updateNoteFields({
           note: {
@@ -530,10 +527,9 @@ describe("UpdateNoteFieldsTool", () => {
       });
 
       it("should allow public URLs in picture[].url", async () => {
-        mockLookup.mockResolvedValueOnce({
-          address: "151.101.1.67",
-          family: 4,
-        } as any);
+        mockLookup.mockResolvedValueOnce([
+          { address: "151.101.1.67", family: 4 },
+        ]);
 
         ankiClient.invoke
           .mockResolvedValueOnce([mockNotes.spanish]) // notesInfo
@@ -563,8 +559,8 @@ describe("UpdateNoteFieldsTool", () => {
       it("validates both audio and picture URLs in same request", async () => {
         // Audio URL is fine, picture URL resolves to private IP
         mockLookup
-          .mockResolvedValueOnce({ address: "93.184.216.34", family: 4 })
-          .mockResolvedValueOnce({ address: "10.0.0.1", family: 4 });
+          .mockResolvedValueOnce([{ address: "93.184.216.34", family: 4 }])
+          .mockResolvedValueOnce([{ address: "10.0.0.1", family: 4 }]);
 
         const result = await tool.updateNoteFields({
           note: {
@@ -597,10 +593,7 @@ describe("UpdateNoteFieldsTool", () => {
 
     describe("media filename sanitization", () => {
       it("sanitizes audio filename path traversal", async () => {
-        mockLookup.mockResolvedValue({
-          address: "93.184.216.34",
-          family: 4,
-        } as any);
+        mockLookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
 
         // Mock the notesInfo call that happens before updateNoteFields
         ankiClient.invoke.mockImplementation(async (action: string) => {

--- a/src/mcp/utils/__tests__/media-validation.utils.spec.ts
+++ b/src/mcp/utils/__tests__/media-validation.utils.spec.ts
@@ -29,8 +29,13 @@ jest.mock("node:dns", () => {
   };
 });
 
-const mockLookup = dns.promises.lookup as jest.MockedFunction<
-  typeof dns.promises.lookup
+// Cast to the `{ all: true }` overload of dns.promises.lookup, which the
+// implementation uses (returns LookupAddress[] instead of a single address)
+const mockLookup = dns.promises.lookup as unknown as jest.MockedFunction<
+  (
+    hostname: string,
+    options: dns.LookupAllOptions,
+  ) => Promise<dns.LookupAddress[]>
 >;
 
 // ── validateMediaFilePath ───────────────────────────────────────────────────
@@ -238,7 +243,7 @@ describe("validateMediaUrl", () => {
 
   describe("allows normal HTTP/HTTPS URLs", () => {
     it("allows http URL", async () => {
-      mockLookup.mockResolvedValue({ address: "93.184.216.34", family: 4 });
+      mockLookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
 
       const result = await validateMediaUrl("http://example.com/audio.mp3");
       expect(result.hostname).toBe("example.com");
@@ -246,7 +251,7 @@ describe("validateMediaUrl", () => {
     });
 
     it("allows https URL", async () => {
-      mockLookup.mockResolvedValue({ address: "93.184.216.34", family: 4 });
+      mockLookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
 
       const result = await validateMediaUrl("https://example.com/image.jpg");
       expect(result.hostname).toBe("example.com");
@@ -254,7 +259,7 @@ describe("validateMediaUrl", () => {
     });
 
     it("allows URLs with ports", async () => {
-      mockLookup.mockResolvedValue({ address: "93.184.216.34", family: 4 });
+      mockLookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
 
       const result = await validateMediaUrl(
         "https://example.com:8080/file.mp3",
@@ -309,7 +314,7 @@ describe("validateMediaUrl", () => {
     ] as const;
 
     it.each(blockedIps)("blocks %s (%s)", async (ip) => {
-      mockLookup.mockResolvedValue({ address: ip, family: 4 });
+      mockLookup.mockResolvedValue([{ address: ip, family: 4 }]);
 
       await expect(
         validateMediaUrl("http://internal-host/file.mp3"),
@@ -317,7 +322,7 @@ describe("validateMediaUrl", () => {
     });
 
     it("provides helpful error message", async () => {
-      mockLookup.mockResolvedValue({ address: "192.168.1.1", family: 4 });
+      mockLookup.mockResolvedValue([{ address: "192.168.1.1", family: 4 }]);
 
       await expect(validateMediaUrl("http://my-nas/file.mp3")).rejects.toThrow(
         /private\/internal networks/,
@@ -325,37 +330,83 @@ describe("validateMediaUrl", () => {
     });
 
     it("blocks 0.0.0.0 (unspecified)", async () => {
-      mockLookup.mockResolvedValue({ address: "0.0.0.0", family: 4 });
+      mockLookup.mockResolvedValue([{ address: "0.0.0.0", family: 4 }]);
       await expect(
         validateMediaUrl("http://zero-host/file.mp3"),
       ).rejects.toThrow(MediaUrlBlockedError);
     });
 
     it("blocks carrier-grade NAT (100.64.x.x)", async () => {
-      mockLookup.mockResolvedValue({ address: "100.64.0.1", family: 4 });
+      mockLookup.mockResolvedValue([{ address: "100.64.0.1", family: 4 }]);
       await expect(
         validateMediaUrl("http://cgnat-host/file.mp3"),
       ).rejects.toThrow(MediaUrlBlockedError);
     });
 
     it("blocks multicast addresses (224.x.x.x)", async () => {
-      mockLookup.mockResolvedValue({ address: "224.0.0.1", family: 4 });
+      mockLookup.mockResolvedValue([{ address: "224.0.0.1", family: 4 }]);
       await expect(
         validateMediaUrl("http://multicast-host/file.mp3"),
       ).rejects.toThrow(MediaUrlBlockedError);
     });
 
     it("blocks broadcast address (255.255.255.255)", async () => {
-      mockLookup.mockResolvedValue({ address: "255.255.255.255", family: 4 });
+      mockLookup.mockResolvedValue([
+        { address: "255.255.255.255", family: 4 },
+      ]);
       await expect(
         validateMediaUrl("http://broadcast-host/file.mp3"),
       ).rejects.toThrow(MediaUrlBlockedError);
     });
   });
 
+  describe("multi-record DNS resolution", () => {
+    it("blocks when first record is public but a sibling is private", async () => {
+      mockLookup.mockResolvedValue([
+        { address: "8.8.8.8", family: 4 },
+        { address: "10.0.0.1", family: 4 },
+      ]);
+
+      await expect(
+        validateMediaUrl("http://multi-host.com/file.mp3"),
+      ).rejects.toThrow(MediaUrlBlockedError);
+    });
+
+    it("blocks when a sibling record is an IPv6-embedded internal target", async () => {
+      // ::a9fe:a9fe is IPv4-compatible hex form of 169.254.169.254 (cloud metadata)
+      mockLookup.mockResolvedValue([
+        { address: "8.8.8.8", family: 4 },
+        { address: "::a9fe:a9fe", family: 6 },
+      ]);
+
+      await expect(
+        validateMediaUrl("http://multi-host.com/file.mp3"),
+      ).rejects.toThrow(MediaUrlBlockedError);
+    });
+
+    it("allows when all records are public and returns the first as resolvedIp", async () => {
+      mockLookup.mockResolvedValue([
+        { address: "8.8.8.8", family: 4 },
+        { address: "1.1.1.1", family: 4 },
+      ]);
+
+      const result = await validateMediaUrl("http://multi-host.com/file.mp3");
+      expect(result.hostname).toBe("multi-host.com");
+      expect(result.resolvedIp).toBe("8.8.8.8");
+    });
+
+    it("rejects when resolution returns no addresses", async () => {
+      mockLookup.mockResolvedValue([]);
+
+      await expect(
+        validateMediaUrl("http://empty-host.com/file.mp3"),
+      ).rejects.toThrow(MediaUrlInvalidError);
+    });
+  });
+
   describe("MEDIA_ALLOWED_HOSTS env var", () => {
     it("allows whitelisted hostname", async () => {
-      mockLookup.mockResolvedValue({ address: "192.168.1.50", family: 4 });
+      mockLookup.mockResolvedValue([{ address: "192.168.1.50", family: 4 }]);
 
       const result = await validateMediaUrl("http://my-nas/file.mp3", {
         allowedHosts: ["my-nas"],
@@ -365,7 +416,7 @@ describe("validateMediaUrl", () => {
     });
 
     it("allows whitelisted IP", async () => {
-      mockLookup.mockResolvedValue({ address: "10.0.0.5", family: 4 });
+      mockLookup.mockResolvedValue([{ address: "10.0.0.5", family: 4 }]);
 
       const result = await validateMediaUrl("http://internal/file.mp3", {
         allowedHosts: ["10.0.0.5"],
@@ -374,7 +425,7 @@ describe("validateMediaUrl", () => {
     });
 
     it("still blocks non-whitelisted private IPs", async () => {
-      mockLookup.mockResolvedValue({ address: "192.168.1.100", family: 4 });
+      mockLookup.mockResolvedValue([{ address: "192.168.1.100", family: 4 }]);
 
       await expect(
         validateMediaUrl("http://other-host/file.mp3", {
@@ -384,9 +435,101 @@ describe("validateMediaUrl", () => {
     });
 
     it("does not bypass blocking with empty allowedHosts array", async () => {
-      mockLookup.mockResolvedValue({ address: "192.168.1.1", family: 4 });
+      mockLookup.mockResolvedValue([{ address: "192.168.1.1", family: 4 }]);
       await expect(
         validateMediaUrl("http://internal/file.mp3", { allowedHosts: [] }),
+      ).rejects.toThrow(MediaUrlBlockedError);
+    });
+
+    it("blocks multi-record host when only one of its IPs is allowlisted", async () => {
+      // IP-based escape hatch requires EVERY resolved address to be
+      // allowlisted — one allowlisted IP must not whitelist a sibling
+      mockLookup.mockResolvedValue([
+        { address: "10.0.0.5", family: 4 },
+        { address: "192.168.1.99", family: 4 },
+      ]);
+
+      await expect(
+        validateMediaUrl("http://internal/file.mp3", {
+          allowedHosts: ["10.0.0.5"],
+        }),
+      ).rejects.toThrow(MediaUrlBlockedError);
+    });
+
+    it("matches unbracketed IPv6 allowedHosts entry against bracketed URL host", async () => {
+      // URL.hostname keeps brackets for IPv6 literals ("[::1]") while users
+      // naturally allowlist the unbracketed form ("::1") — both must match
+      mockLookup.mockResolvedValue([{ address: "::1", family: 6 }]);
+
+      const result = await validateMediaUrl("http://[::1]:8080/file.mp3", {
+        allowedHosts: ["::1"],
+      });
+      expect(result.hostname).toBe("[::1]");
+      expect(result.resolvedIp).toBe("::1");
+    });
+
+    it("hostname allowlist bypasses per-address range checks (escape hatch)", async () => {
+      // Documents intended semantics: listing a host BY NAME is an explicit
+      // opt-in that deliberately skips per-address range validation, even if
+      // the host resolves to private/internal siblings. A future refactor must
+      // not silently tighten this into a per-IP check.
+      mockLookup.mockResolvedValue([
+        { address: "8.8.8.8", family: 4 },
+        { address: "192.168.1.50", family: 4 },
+      ]);
+
+      const result = await validateMediaUrl("http://my-nas/file.mp3", {
+        allowedHosts: ["my-nas"],
+      });
+      expect(result.hostname).toBe("my-nas");
+      expect(result.resolvedIp).toBe("8.8.8.8");
+    });
+
+    it("matches non-canonical IPv6 allowedHosts entry against canonical resolved address", async () => {
+      // IP-based match compares by normalized value: the expanded form
+      // "fd00:0:0:0:0:0:0:1" and the compressed resolved "fd00::1" are the same
+      // address, so the escape hatch must apply despite the raw strings differing.
+      mockLookup.mockResolvedValue([{ address: "fd00::1", family: 6 }]);
+
+      const result = await validateMediaUrl("http://ipv6-nas/file.mp3", {
+        allowedHosts: ["fd00:0:0:0:0:0:0:1"],
+      });
+      expect(result.resolvedIp).toBe("fd00::1");
+    });
+
+    it("matches bare IPv4 allowedHosts entry against IPv4-mapped resolved address", async () => {
+      // normalizeIp routes through embedded-IPv4 extraction, so the mapped form
+      // "::ffff:10.0.0.5" and the bare "10.0.0.5" both normalize to "10.0.0.5".
+      // Before this fix the mapped resolved address would not match the bare
+      // allowlist entry and the request would be blocked (fail-closed miss).
+      mockLookup.mockResolvedValue([{ address: "::ffff:10.0.0.5", family: 6 }]);
+
+      const result = await validateMediaUrl("http://internal/file.mp3", {
+        allowedHosts: ["10.0.0.5"],
+      });
+      expect(result.resolvedIp).toBe("::ffff:10.0.0.5");
+    });
+
+    it("matches IPv4-mapped allowedHosts entry against bare IPv4 resolved address", async () => {
+      // Reverse direction: the allowlist entry is the mapped form and the host
+      // resolves to the bare IPv4 — normalization makes both "10.0.0.5".
+      mockLookup.mockResolvedValue([{ address: "10.0.0.5", family: 4 }]);
+
+      const result = await validateMediaUrl("http://internal/file.mp3", {
+        allowedHosts: ["::ffff:10.0.0.5"],
+      });
+      expect(result.resolvedIp).toBe("10.0.0.5");
+    });
+
+    it("does not match a different IP even across mapped/bare forms", async () => {
+      // Negative guard: extraction is lossless and distinct IPs never collide,
+      // so allowlisting 10.0.0.5 must NOT let a sibling 10.0.0.6 through.
+      mockLookup.mockResolvedValue([{ address: "10.0.0.6", family: 4 }]);
+
+      await expect(
+        validateMediaUrl("http://internal/file.mp3", {
+          allowedHosts: ["10.0.0.5"],
+        }),
       ).rejects.toThrow(MediaUrlBlockedError);
     });
   });
@@ -415,7 +558,7 @@ describe("validateMediaUrl", () => {
 
   describe("IPv6 handling", () => {
     it("blocks IPv6 loopback", async () => {
-      mockLookup.mockResolvedValue({ address: "::1", family: 6 });
+      mockLookup.mockResolvedValue([{ address: "::1", family: 6 }]);
 
       await expect(
         validateMediaUrl("http://localhost/file.mp3"),
@@ -423,10 +566,9 @@ describe("validateMediaUrl", () => {
     });
 
     it("blocks IPv4-mapped IPv6 private addresses", async () => {
-      mockLookup.mockResolvedValue({
-        address: "::ffff:192.168.1.1",
-        family: 6,
-      });
+      mockLookup.mockResolvedValue([
+        { address: "::ffff:192.168.1.1", family: 6 },
+      ]);
 
       await expect(
         validateMediaUrl("http://internal/file.mp3"),
@@ -435,27 +577,90 @@ describe("validateMediaUrl", () => {
 
     it("allows public IPv6 addresses", async () => {
       // 2607:f8b0:4004:800::200e is a Google public IPv6 address (unicast range)
-      mockLookup.mockResolvedValue({
-        address: "2607:f8b0:4004:800::200e",
-        family: 6,
-      });
+      mockLookup.mockResolvedValue([
+        { address: "2607:f8b0:4004:800::200e", family: 6 },
+      ]);
 
       const result = await validateMediaUrl("http://ipv6host.com/file.mp3");
       expect(result.resolvedIp).toBe("2607:f8b0:4004:800::200e");
     });
 
     it("blocks IPv6 unique-local (fc00::/fd00::)", async () => {
-      mockLookup.mockResolvedValue({ address: "fd12:3456:789a::1", family: 6 });
+      mockLookup.mockResolvedValue([
+        { address: "fd12:3456:789a::1", family: 6 },
+      ]);
       await expect(
         validateMediaUrl("http://ipv6-local/file.mp3"),
       ).rejects.toThrow(MediaUrlBlockedError);
     });
 
     it("blocks IPv6 literal loopback URL", async () => {
-      mockLookup.mockResolvedValue({ address: "::1", family: 6 });
+      mockLookup.mockResolvedValue([{ address: "::1", family: 6 }]);
       await expect(validateMediaUrl("http://[::1]/file.mp3")).rejects.toThrow(
         MediaUrlBlockedError,
       );
+    });
+  });
+
+  describe("blocks IPv6 transition addresses (SSRF bypass)", () => {
+    // These ranges are IPv6-to-IPv4 transition mechanisms that can wrap
+    // internal IPv4 targets (e.g. cloud metadata). The allowlist (unicast-only)
+    // rejects them all — GHSA-5286-6cm5-w3qv.
+    const transitionIps = [
+      ["64:ff9b::169.254.169.254", "rfc6052 / NAT64 wrapping cloud metadata"],
+      ["2002:a9fe:a9fe::", "6to4"],
+      ["2001:0:4136:e378:8000:63bf:3fff:fdd2", "teredo"],
+      ["::ffff:0:169.254.169.254", "rfc6145 / SIIT"],
+      ["::ffff:169.254.169.254", "IPv4-mapped wrapping cloud metadata"],
+      ["::a9fe:a9fe", "IPv4-compatible (hex form) wrapping cloud metadata"],
+      ["::7f00:1", "IPv4-compatible (hex form) wrapping loopback"],
+    ] as const;
+
+    it.each(transitionIps)("blocks %s (%s)", async (ip) => {
+      mockLookup.mockResolvedValue([{ address: ip, family: 6 }]);
+
+      await expect(
+        validateMediaUrl("http://transition-host/file.mp3"),
+      ).rejects.toThrow(MediaUrlBlockedError);
+    });
+
+    it("blocks IPv4-mapped private addresses after extraction", async () => {
+      mockLookup.mockResolvedValue([{ address: "::ffff:10.0.0.1", family: 6 }]);
+
+      await expect(
+        validateMediaUrl("http://mapped-private/file.mp3"),
+      ).rejects.toThrow(MediaUrlBlockedError);
+    });
+  });
+
+  describe("allowlist does not over-block legitimate public traffic", () => {
+    it("allows public IPv4", async () => {
+      mockLookup.mockResolvedValue([{ address: "8.8.8.8", family: 4 }]);
+
+      const result = await validateMediaUrl("http://public-host.com/file.mp3");
+      expect(result.hostname).toBe("public-host.com");
+      expect(result.resolvedIp).toBe("8.8.8.8");
+    });
+
+    it("allows public IPv6 (Cloudflare)", async () => {
+      mockLookup.mockResolvedValue([
+        { address: "2606:4700:4700::1111", family: 6 },
+      ]);
+
+      const result = await validateMediaUrl("http://cf-host.com/file.mp3");
+      expect(result.hostname).toBe("cf-host.com");
+      expect(result.resolvedIp).toBe("2606:4700:4700::1111");
+    });
+
+    it("allows IPv4-mapped public addresses via extraction", async () => {
+      // ipaddr.js reports "ipv4Mapped" (not "unicast") for ::ffff:8.8.8.8.
+      // The mapped-extraction branch converts it to 8.8.8.8 (unicast) before
+      // the allowlist check — regression guard against over-blocking.
+      mockLookup.mockResolvedValue([{ address: "::ffff:8.8.8.8", family: 6 }]);
+
+      const result = await validateMediaUrl("http://mapped-public/file.mp3");
+      expect(result.hostname).toBe("mapped-public");
+      expect(result.resolvedIp).toBe("::ffff:8.8.8.8");
     });
   });
 });

--- a/src/mcp/utils/media-validation.utils.ts
+++ b/src/mcp/utils/media-validation.utils.ts
@@ -78,21 +78,81 @@ export interface MediaUrlConfig {
 
 const DEFAULT_ALLOWED_PREFIXES = ["image/", "audio/", "video/"];
 
-// ── IP ranges that should be blocked for SSRF prevention ────────────────────
+// ── SSRF range allowlist ────────────────────────────────────────────────────
 
-const BLOCKED_RANGES = new Set([
-  "private",
-  "loopback",
-  "linkLocal",
-  "reserved",
-  "unspecified",
-  // IPv6-specific blocked ranges
-  "uniqueLocal",
-  // Additional ranges
-  "carrierGradeNat",
-  "multicast",
-  "broadcast",
-]);
+// SSRF guard: allowlist approach (fail-closed). Only ordinary public unicast
+// addresses may be fetched. Every other ipaddr.js range — private, loopback,
+// linkLocal, reserved, unspecified, uniqueLocal, carrierGradeNat, multicast,
+// broadcast, and IPv6 transition ranges (rfc6052/NAT64, rfc6145/SIIT, 6to4,
+// teredo, benchmarking, amt) — is rejected, including any range ipaddr.js may
+// add in future versions. IPv6 addresses that embed an IPv4 target (IPv4-mapped
+// ::ffff:0:0/96 and deprecated IPv4-compatible ::/96) are classified by the
+// embedded IPv4 instead: it is extracted first, then re-checked against this
+// allowlist, so wrapping an internal IPv4 in IPv6 does not bypass the guard.
+const ALLOWED_RANGE = "unicast";
+
+function isPublicUnicast(addr: ipaddr.IPv4 | ipaddr.IPv6): boolean {
+  return addr.range() === ALLOWED_RANGE;
+}
+
+// Deprecated IPv4-compatible IPv6 (::/96, RFC 4291 §2.5.5.1): top 96 bits are
+// zero, IPv4 embedded in the low 32 bits. ipaddr.js classifies the hex-group
+// form (e.g. ::a9fe:a9fe ≡ 169.254.169.254) as plain "unicast", so without
+// extraction it would pass the allowlist while targeting an internal IPv4.
+// Strictly requires parts[0..5] === 0, so it never matches IPv4-mapped
+// (parts[5] === 0xffff) or rfc6145/SIIT (::ffff:0:0/96). Also matches "::" and
+// "::1", which extract to 0.0.0.0 / 0.0.0.1 → non-unicast → blocked (fail-closed).
+function isIPv4CompatibleAddress(ipv6: ipaddr.IPv6): boolean {
+  return ipv6.parts.slice(0, 6).every((part) => part === 0);
+}
+
+// Build the embedded IPv4 from the low 32 bits (two 16-bit groups). ipaddr.js's
+// toIPv4Address() only accepts IPv4-mapped addresses, so construct it manually.
+function extractEmbeddedIPv4(ipv6: ipaddr.IPv6): ipaddr.IPv4 {
+  const high = ipv6.parts[6];
+  const low = ipv6.parts[7];
+  return new ipaddr.IPv4([high >> 8, high & 0xff, low >> 8, low & 0xff]);
+}
+
+// Parse an IP string and, for IPv6 that embeds an IPv4 target (IPv4-mapped
+// ::ffff:0:0/96 or deprecated IPv4-compatible ::/96), return the embedded IPv4
+// so downstream checks classify the real target. Returns null for
+// non-IP / unparseable input. Uses `instanceof ipaddr.IPv6` for narrowing so no
+// type cast is needed. Extraction is lossless — distinct addresses never
+// collapse to the same value.
+function parseTargetAddress(ip: string): ipaddr.IPv4 | ipaddr.IPv6 | null {
+  if (!ipaddr.isValid(ip)) return null;
+  let addr: ipaddr.IPv4 | ipaddr.IPv6 = ipaddr.parse(ip);
+  if (addr instanceof ipaddr.IPv6) {
+    if (addr.isIPv4MappedAddress()) addr = addr.toIPv4Address();
+    else if (isIPv4CompatibleAddress(addr)) addr = extractEmbeddedIPv4(addr);
+  }
+  return addr;
+}
+
+// Validate a single resolved address against the SSRF allowlist: parse it,
+// extract any embedded IPv4 target (mapped ::ffff:0:0/96 or deprecated
+// IPv4-compatible ::/96) so the check classifies the real target, then
+// require public unicast. Throws MediaUrlBlockedError on any failure
+// (fail-closed, including unparseable addresses).
+function assertAddressAllowed(ip: string): void {
+  const addr = parseTargetAddress(ip);
+  if (!addr || !isPublicUnicast(addr)) {
+    throw new MediaUrlBlockedError();
+  }
+}
+
+// Canonicalize an IP string for equality comparison. Routes through the same
+// embedded-IPv4 extraction as the SSRF check, so equivalent forms of the same
+// target compare equal (e.g. "::ffff:10.0.0.5" and "10.0.0.5" both normalize to
+// "10.0.0.5"; "::a9fe:a9fe" normalizes to "169.254.169.254"). Also collapses
+// compressed vs expanded IPv6 ("fd00::1" and "fd00:0:0:0:0:0:0:1" → "fd00::1").
+// Returns null for non-IP strings (hostnames), which are matched separately by
+// name and never participate in IP comparison. Extraction is lossless, so two
+// genuinely-different targets never normalize to the same string.
+function normalizeIp(value: string): string | null {
+  return parseTargetAddress(value)?.toString() ?? null;
+}
 
 // ── Path validation ─────────────────────────────────────────────────────────
 
@@ -156,16 +216,16 @@ export function validateMediaFilePath(
  * Checks:
  * 1. URL is valid and parseable
  * 2. Scheme is http: or https:
- * 3. Resolved IP is not in a private/reserved range (unless host is in allowedHosts)
+ * 3. ALL resolved IPs are public unicast addresses (unless host is in allowedHosts)
  *
- * NOTE: This validation is subject to DNS rebinding (TOCTOU). We resolve and validate the IP here,
+ * NOTE: This validation is subject to DNS rebinding (TOCTOU). We resolve and validate the IPs here,
  * but AnkiConnect re-resolves the hostname when fetching. An attacker controlling DNS could return
  * a public IP for our check and a private IP for AnkiConnect's fetch. This is an inherent limitation
  * when we cannot control the downstream HTTP client.
  *
- * @throws MediaUrlInvalidError if the URL cannot be parsed
+ * @throws MediaUrlInvalidError if the URL cannot be parsed or the hostname does not resolve
  * @throws MediaUrlSchemeError if the scheme is not http(s)
- * @throws MediaUrlBlockedError if the resolved IP is in a blocked range
+ * @throws MediaUrlBlockedError if any resolved IP is not a public unicast address
  */
 export async function validateMediaUrl(
   input: string,
@@ -192,44 +252,56 @@ export async function validateMediaUrl(
       ? hostname.slice(1, -1)
       : hostname;
 
-  // Resolve hostname to IP
-  let resolvedIp: string;
+  // Resolve hostname to ALL its addresses. A host can have multiple A/AAAA
+  // records; validating only the first would let a sibling private/internal
+  // record slip through the guard.
+  let resolved: dns.LookupAddress[];
   try {
-    const result = await dns.promises.lookup(hostnameForLookup);
-    resolvedIp = result.address;
+    resolved = await dns.promises.lookup(hostnameForLookup, { all: true });
   } catch {
     throw new MediaUrlInvalidError();
   }
+  if (resolved.length === 0) {
+    throw new MediaUrlInvalidError();
+  }
 
-  // Check if host is in the allowed list (skip range check if so)
+  // First resolved address, returned for informational purposes (backward compat)
+  const resolvedIp = resolved[0].address;
+
+  // Check if host is in the allowed list (skip range checks if so).
+  // Semantics: the escape hatch is an explicit user opt-in for a host, so it
+  // applies when the user listed this host by name — hostname matches either
+  // as-is or with IPv6-literal brackets stripped (hostnameForLookup), so
+  // "::1" and "[::1]" both work — OR by IP, where EVERY resolved address must
+  // be individually allowlisted. Requiring all addresses prevents a
+  // multi-record host from piggybacking a non-allowlisted internal address
+  // on one allowlisted IP.
   if (config.allowedHosts && config.allowedHosts.length > 0) {
-    const isAllowed = config.allowedHosts.some(
-      (allowed) => allowed === hostname || allowed === resolvedIp,
-    );
-    if (isAllowed) {
+    const allowedHosts = config.allowedHosts;
+    const hostnameAllowed =
+      allowedHosts.includes(hostname) ||
+      allowedHosts.includes(hostnameForLookup);
+    // IP-based match compares by NORMALIZED value so an allowlist entry written
+    // in a different-but-equivalent form (compressed vs expanded IPv6, or an
+    // embedded-IPv4 IPv6 vs the bare IPv4) still matches the resolved address.
+    // Non-IP entries normalize to null and are ignored here (already handled by
+    // the hostname match above).
+    const allowedIps = allowedHosts
+      .map(normalizeIp)
+      .filter((ip): ip is string => ip !== null);
+    const allIpsAllowed = resolved.every(({ address }) => {
+      const normalized = normalizeIp(address);
+      return normalized !== null && allowedIps.includes(normalized);
+    });
+    if (hostnameAllowed || allIpsAllowed) {
       return { hostname, resolvedIp };
     }
   }
 
-  // Parse and check IP range
-  let addr: ipaddr.IPv4 | ipaddr.IPv6;
-  try {
-    addr = ipaddr.parse(resolvedIp);
-  } catch {
-    throw new MediaUrlBlockedError();
-  }
-
-  // For IPv4-mapped IPv6 addresses, extract the IPv4 part
-  if (addr.kind() === "ipv6") {
-    const ipv6 = addr as ipaddr.IPv6;
-    if (ipv6.isIPv4MappedAddress()) {
-      addr = ipv6.toIPv4Address();
-    }
-  }
-
-  const range = addr.range();
-  if (BLOCKED_RANGES.has(range)) {
-    throw new MediaUrlBlockedError();
+  // Every resolved address must pass the allowlist — reject if ANY is not a
+  // public unicast target
+  for (const { address } of resolved) {
+    assertAddressAllowed(address);
   }
 
   return { hostname, resolvedIp };


### PR DESCRIPTION
## Summary

Fixes **GHSA-5286-6cm5-w3qv** — SSRF guard bypass in media-URL validation via IPv6 transition addresses — plus related hardening.

`validateMediaUrl()` used a range **blocklist** that missed the IPv6 transition ranges `ipaddr.js` can return (`rfc6052`/NAT64, `rfc6145`/SIIT, `6to4`, `teredo`, `benchmarking`, `amt`). An attacker could reach internal targets via a literal like `http://[64:ff9b::169.254.169.254]/` that encodes a private IPv4.

## Changes

- **Blocklist → fail-closed allowlist** — only `ipaddr.js` `unicast` is permitted; the entire transition-range class (and any range future `ipaddr.js` versions add) is blocked by default.
- **Embedded-IPv4 extraction** — both IPv4-mapped (`::ffff:0:0/96`) and deprecated IPv4-compatible (`::/96`, e.g. `::a9fe:a9fe`) are unwrapped and re-checked, so an internal IPv4 wrapped in IPv6 can't bypass the guard.
- **All DNS records validated** — a host with a public record and a private sibling is now rejected (previously only the first record was checked).
- **`allowedHosts` matching** normalizes IPs (embedded-IPv4 + IPv6 form) and handles bracketed IPv6 literals; the IP escape hatch requires every resolved address to be allowlisted.

## Testing

Full suite green — **1288/1288**. Adds 12 targeted tests (transition ranges, embedded-IPv4 forms, multi-record resolution, allowlist normalization) and migrates existing tool-spec DNS mocks to the multi-address (`{ all: true }`) shape.

Reported by tonghuaroot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
