### PR TITLE
style: apply prettier to media-validation spec

### DIFF
--- a/src/mcp/utils/__tests__/media-validation.utils.spec.ts
+++ b/src/mcp/utils/__tests__/media-validation.utils.spec.ts
@@ -351,9 +351,7 @@ describe("validateMediaUrl", () => {
     });
 
     it("blocks broadcast address (255.255.255.255)", async () => {
-      mockLookup.mockResolvedValue([
-        { address: "255.255.255.255", family: 4 },
-      ]);
+      mockLookup.mockResolvedValue([{ address: "255.255.255.255", family: 4 }]);
       await expect(
         validateMediaUrl("http://broadcast-host/file.mp3"),
       ).rejects.toThrow(MediaUrlBlockedError);


### PR DESCRIPTION
Collapses a multi-line mock array to prettier's canonical single-line form so the file is formatter-clean. No behavior change; tests unaffected (1288/1288). Follow-up to the v0.22.5 security release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)