### PR TITLE
fix(stats): honest due-tree vs card-state semantics + true state counts (v0.23.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
+## [0.23.0] - 2026-08
+
+- **`deckStats` / `collection_stats`: honest count semantics** (fixes #50). `counts.new/learning/review` are AnkiConnect due-tree numbers — cards due _today_, capped by daily limits — not card-state totals, and `other` is an arithmetic remainder (mostly review cards not due today plus new cards beyond the daily limit), not "suspended/buried". All tool descriptions now say so; this corrects the `total == new + learning + review + other` framing introduced in 0.18.0, which is not guaranteed (`other` is clamped at 0 and filtered decks can break the identity).
+- **New `states` block** with true card-state counts (new / learning / review / suspended / buried) computed from Anki searches — unaffected by due dates and daily limits. Per-deck on `deckStats`, collection-level on `collection_stats`. The five values are mutually exclusive and cover every card in scope (relearning cards count as `learning`). Costs 5 additional searches per call.
+- **`listDecks` summary bugfix**: `new_cards`/`learning_cards`/`review_cards` no longer double-count subdecks (per-deck buckets are already rolled up over children; the summary now sums root decks only). Numbers shrink for collections with subdecks — they were inflated before. `total_cards` is unchanged (own-cards-only, correct as it was).
+- **Deck-name escaping hardened** in `deckStats`, `collection_stats`, `get_cards`, `get_due_cards`: `_`, `*`, and `\` in deck names are now escaped as literals in generated Anki searches (previously `JLPT_N5` could silently match sibling decks; `Math\Physics` errored). `::` is untouched — nested deck names keep working.
+- Stricter response validation on `findCards`/`getEaseFactors`/`getIntervals` payloads (throw instead of silently reporting 0).
+
 ## [0.18.0] - 2026-04
+
 - `changeDeck` + `rate_card` now validate card IDs via `cardsInfo` before mutation (was silent-success on invalid IDs).
 - `collection_stats` + `deckStats` add an `other` bucket so `total == new + learning + review + other` (captures suspended/buried cards); `per_deck` invariant: length always matches `total_decks`.
 - `createDeck` distinguishes "created parent" vs "found existing parent" in message + adds `parentExisted` field.
@@ -11,16 +20,20 @@
 - Fixed stale snake_case references to camelCase tool names across hints, prompts, and GUI tools.
 
 ## [0.17.0] - 2026-04
+
 - Relicensed from AGPL-3.0-or-later to MIT
 - Fixed manifest.json `author.url` to point at GitHub profile (required by Anthropic MCPB directory)
 
 ## [0.15.1] - 2026-04
+
 - Optimize README hero image; fix npm upgrade crash in publish workflows (npm/cli#9151).
 
 ## [0.15.0] - 2026-03
+
 - Media path-traversal and SSRF protection; E2E tests for media security guards; switch npm publishing to OIDC Trusted Publishing.
 
 ## [0.14.0] - 2026-02
+
 - Improve MCP tool definitions for toolbench score; add bulk `addNotes` tool; fix deck stats resolution for child decks.
 
 ---

--- a/README.md
+++ b/README.md
@@ -49,10 +49,12 @@ The server exposes **42 MCP tools** — 31 essential tools for everyday Anki ope
 > **Note:** Card `front`/`back` content is rendered per card from its own template (as Anki shows it), so reversed and cloze cards display the correct direction. Static text added by your card templates appears in the output as well.
 
 #### Deck Management
-- `listDecks` - List all decks, optionally with per-deck card-count statistics
-- `deckStats` - Get comprehensive statistics for a single deck (counts, ease/interval distributions)
+- `listDecks` - List all decks, optionally with per-deck study-queue statistics
+- `deckStats` - Get comprehensive statistics for a single deck (study queue, true card-state counts, ease/interval distributions)
 - `createDeck` - Create a new empty deck (supports `Parent::Child`, max 2 levels)
 - `changeDeck` - Move cards to a different deck (created if it doesn't exist)
+
+> **Note:** Deck statistics come in two flavours. The `counts` block (and everything `listDecks` reports) mirrors Anki's deck browser: cards **due today**, capped by each deck's **daily new/review limits**, with suspended and buried cards excluded — so `review` is not "mature cards" and the `other` bucket is just the arithmetic remainder (mostly review cards not due today plus new cards over the daily limit). For true per-state totals use the `states` block on `deckStats` / `collection_stats`, which counts `new`, `learning`, `review`, `suspended` and `buried` via Anki searches, ignoring due dates and daily limits.
 
 #### Note Management
 - `addNote` - Create a single note with specified fields and tags
@@ -96,7 +98,7 @@ Just tell Claude where the image is, and it will handle the upload automatically
 - `repositionModelField` - Change the position of a field within an existing note type
 
 #### Statistics
-- `collection_stats` - Aggregated statistics across all decks with per-deck breakdown
+- `collection_stats` - Aggregated statistics across all decks with per-deck breakdown and collection-wide card-state counts
 - `review_stats` - Review history analysis (temporal patterns, retention metrics, study streaks)
 
 ### GUI Tools

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "anki-mcp-server",
   "display_name": "Anki MCP Server",
-  "version": "0.22.5",
+  "version": "0.23.0",
   "license": "MIT",
   "description": "Model Context Protocol server for Anki spaced repetition flashcard application",
   "long_description": "Transform your Anki experience with natural language interaction - like having a private tutor. This MCP server enables AI assistants to interact with Anki, allowing them to explain concepts, make learning more engaging, provide context, and adapt to your learning style. Features include review sessions, deck management, note creation and editing, and more.\n\nRequires Anki with the AnkiConnect plugin installed.",
@@ -177,11 +177,11 @@
     },
     {
       "name": "listDecks",
-      "description": "List all Anki decks, optionally with card count statistics for each deck"
+      "description": "List all Anki decks, optionally with per-deck study-queue counts (cards due today, capped by daily limits — not card totals)"
     },
     {
       "name": "deckStats",
-      "description": "Get comprehensive statistics for a single deck including card counts, ease and interval distributions"
+      "description": "Get statistics for a single deck: today's study queue, true card-state counts (new/learning/review/suspended/buried), and ease/interval distributions"
     },
     {
       "name": "createDeck",
@@ -225,7 +225,7 @@
     },
     {
       "name": "collection_stats",
-      "description": "Get aggregated statistics across all decks in the collection with per-deck breakdown"
+      "description": "Get aggregated statistics across all decks: per-deck study queues plus collection-wide true card-state counts"
     },
     {
       "name": "review_stats",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ankimcp/anki-mcp-server",
-  "version": "0.22.4",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ankimcp/anki-mcp-server",
-      "version": "0.22.4",
+      "version": "0.23.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ankimcp/anki-mcp-server",
   "mcpName": "ai.ankimcp/anki-mcp-server",
-  "version": "0.22.5",
+  "version": "0.23.0",
   "description": "Model Context Protocol server for Anki - enables AI assistants to interact with your Anki flashcards",
   "author": "Anatoly Tarnavsky",
   "private": false,

--- a/src/mcp/primitives/essential/tools/__tests__/deck-stats.tool.spec.ts
+++ b/src/mcp/primitives/essential/tools/__tests__/deck-stats.tool.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { DeckStatsTool } from "../deck-stats.tool";
 import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
-import { parseToolResult } from "@/test-fixtures/test-helpers";
+import { findCardsFor, parseToolResult } from "@/test-fixtures/test-helpers";
 import type { DeckStatsResult } from "../deckActions/actions/deckStats.action";
 
 jest.mock("@/mcp/clients/anki-connect.client");
@@ -25,7 +25,9 @@ describe("DeckStatsTool", () => {
   it("should return deck stats with distributions", async () => {
     const deckName = "Test Deck";
 
-    ankiClient.invoke.mockImplementation((action: string) => {
+    const allCardIds = Array.from({ length: 35 }, (_, i) => i + 1);
+
+    ankiClient.invoke.mockImplementation((action: string, params?: any) => {
       if (action === "deckNamesAndIds") {
         return Promise.resolve({ [deckName]: 1234567890 });
       }
@@ -42,7 +44,16 @@ describe("DeckStatsTool", () => {
         });
       }
       if (action === "findCards") {
-        return Promise.resolve(Array.from({ length: 35 }, (_, i) => i + 1));
+        // 35 cards: 12 new, 5 learning, 15 review, 2 suspended, 1 buried.
+        return Promise.resolve(
+          findCardsFor(params.query, allCardIds, {
+            new: allCardIds.slice(0, 12),
+            learning: allCardIds.slice(12, 17),
+            review: allCardIds.slice(17, 32),
+            suspended: allCardIds.slice(32, 34),
+            buried: allCardIds.slice(34, 35),
+          }),
+        );
       }
       if (action === "getEaseFactors") {
         return Promise.resolve([
@@ -66,7 +77,9 @@ describe("DeckStatsTool", () => {
     const rawResult = await tool.execute({ deck: deckName });
     const result = parseToolResult(rawResult) as DeckStatsResult;
 
-    expect(ankiClient.invoke).toHaveBeenCalledTimes(5);
+    // deckNamesAndIds + getDeckStats + findCards(deck) + 5 state queries
+    // + getEaseFactors + getIntervals
+    expect(ankiClient.invoke).toHaveBeenCalledTimes(10);
     expect(result.deck).toBe(deckName);
     expect(result.counts).toEqual({
       total: 35,
@@ -75,14 +88,77 @@ describe("DeckStatsTool", () => {
       review: 20,
       other: 0,
     });
+    // `states` reports true card states, independent of the due-today buckets
+    // in `counts` — note new(12) != counts.new(10) because the deck's daily
+    // new limit caps the scheduler bucket.
+    expect(result.states).toEqual({
+      new: 12,
+      learning: 5,
+      review: 15,
+      suspended: 2,
+      buried: 1,
+    });
+    // The five states partition every card matched by `deck:<name>`.
+    expect(
+      result.states.new +
+        result.states.learning +
+        result.states.review +
+        result.states.suspended +
+        result.states.buried,
+    ).toBe(35);
     expect(result.ease.count).toBe(25);
     expect(result.intervals.count).toBe(20);
+  });
+
+  it("should scope state queries to the deck and escape quotes in its name", async () => {
+    const deckName = 'Say "hi"';
+
+    ankiClient.invoke.mockImplementation((action: string, params?: any) => {
+      if (action === "deckNamesAndIds") {
+        return Promise.resolve({ [deckName]: 42 });
+      }
+      if (action === "getDeckStats") {
+        return Promise.resolve({
+          "42": {
+            deck_id: 42,
+            name: deckName,
+            new_count: 1,
+            learn_count: 0,
+            review_count: 0,
+            total_in_deck: 1,
+          },
+        });
+      }
+      if (action === "findCards") {
+        return Promise.resolve(findCardsFor(params.query, [1], { new: [1] }));
+      }
+      if (action === "getEaseFactors") return Promise.resolve([0]);
+      if (action === "getIntervals") return Promise.resolve([0]);
+      return Promise.resolve({});
+    });
+
+    await tool.execute({ deck: deckName });
+
+    const queries = ankiClient.invoke.mock.calls
+      .filter(([action]) => action === "findCards")
+      .map(([, params]) => (params as { query: string }).query);
+
+    expect(queries).toEqual([
+      '"deck:Say \\"hi\\""',
+      '"deck:Say \\"hi\\"" is:new -is:suspended -is:buried',
+      '"deck:Say \\"hi\\"" is:learn -is:suspended -is:buried',
+      '"deck:Say \\"hi\\"" is:review -is:learn -is:suspended -is:buried',
+      '"deck:Say \\"hi\\"" is:suspended',
+      '"deck:Say \\"hi\\"" is:buried',
+    ]);
   });
 
   it("should resolve child deck stats by ID when getDeckStats returns short name", async () => {
     const fullDeckName = "Test::STDIO-AddNotes";
 
-    ankiClient.invoke.mockImplementation((action: string) => {
+    const childCardIds = Array.from({ length: 15 }, (_, i) => i + 1);
+
+    ankiClient.invoke.mockImplementation((action: string, params?: any) => {
       if (action === "deckNamesAndIds") {
         return Promise.resolve({
           Test: 1111111111,
@@ -102,7 +178,11 @@ describe("DeckStatsTool", () => {
         });
       }
       if (action === "findCards") {
-        return Promise.resolve(Array.from({ length: 15 }, (_, i) => i + 1));
+        return Promise.resolve(
+          findCardsFor(params.query, childCardIds, {
+            review: childCardIds,
+          }),
+        );
       }
       if (action === "getEaseFactors") {
         return Promise.resolve(Array(15).fill(2500));
@@ -122,6 +202,8 @@ describe("DeckStatsTool", () => {
     expect(result.counts.learning).toBe(2);
     expect(result.counts.review).toBe(8);
     expect(result.counts.other).toBe(0);
+    // All 15 cards are review-state, even though only 8 are due today.
+    expect(result.states.review).toBe(15);
   });
 
   it("should handle deck not found", async () => {
@@ -153,6 +235,9 @@ describe("DeckStatsTool", () => {
           },
         });
       }
+      if (action === "findCards") {
+        return Promise.resolve([]);
+      }
       return Promise.resolve({});
     });
 
@@ -162,8 +247,62 @@ describe("DeckStatsTool", () => {
     expect(result.deck).toBe(deckName);
     expect(result.counts.total).toBe(0);
     expect(result.counts.other).toBe(0);
+    expect(result.states).toEqual({
+      new: 0,
+      learning: 0,
+      review: 0,
+      suspended: 0,
+      buried: 0,
+    });
     expect(result.ease.count).toBe(0);
     expect(result.intervals.count).toBe(0);
+    // Emptiness is decided by the `deck:` search, never by total_in_deck:
+    // deckNamesAndIds + getDeckStats + findCards, then short-circuit.
+    expect(ankiClient.invoke).toHaveBeenCalledTimes(3);
+  });
+
+  it("should trust the deck search over total_in_deck when a filtered deck borrowed the cards", async () => {
+    // A filtered deck holds every card of "Loaned", so AnkiConnect reports
+    // total_in_deck: 0 — but `deck:Loaned` still matches all 4 cards (they
+    // keep their home deck in `odid`). Short-circuiting on counts.total would
+    // report states as all-zero, i.e. lie.
+    const deckName = "Loaned";
+
+    ankiClient.invoke.mockImplementation((action: string, params?: any) => {
+      if (action === "deckNamesAndIds") {
+        return Promise.resolve({ [deckName]: 99 });
+      }
+      if (action === "getDeckStats") {
+        return Promise.resolve({
+          "99": {
+            deck_id: 99,
+            name: deckName,
+            new_count: 0,
+            learn_count: 0,
+            review_count: 0,
+            total_in_deck: 0, // cards live in the filtered deck's row
+          },
+        });
+      }
+      if (action === "findCards") {
+        return Promise.resolve(
+          findCardsFor(params.query, [1, 2, 3, 4], {
+            review: [1, 2, 3, 4],
+          }),
+        );
+      }
+      if (action === "getEaseFactors")
+        return Promise.resolve(Array(4).fill(2500));
+      if (action === "getIntervals") return Promise.resolve(Array(4).fill(10));
+      return Promise.resolve({});
+    });
+
+    const rawResult = await tool.execute({ deck: deckName });
+    const result = parseToolResult(rawResult) as DeckStatsResult;
+
+    expect(result.counts.total).toBe(0);
+    // `states` comes from the search, so it sees the borrowed cards.
+    expect(result.states.review).toBe(4);
   });
 
   it("should report 'other' bucket when total exceeds new+learning+review (Bug #2 regression)", async () => {
@@ -171,7 +310,7 @@ describe("DeckStatsTool", () => {
     // 0 review — the missing card is suspended/buried and should land in `other`.
     const deckName = "Spanish";
 
-    ankiClient.invoke.mockImplementation((action: string) => {
+    ankiClient.invoke.mockImplementation((action: string, params?: any) => {
       if (action === "deckNamesAndIds") {
         return Promise.resolve({ [deckName]: 1651445861967 });
       }
@@ -190,7 +329,12 @@ describe("DeckStatsTool", () => {
       }
 
       if (action === "findCards") {
-        return Promise.resolve([1, 2, 3, 4]);
+        return Promise.resolve(
+          findCardsFor(params.query, [1, 2, 3, 4], {
+            new: [1, 2, 3],
+            suspended: [4],
+          }),
+        );
       }
 
       if (action === "getEaseFactors") {
@@ -221,6 +365,63 @@ describe("DeckStatsTool", () => {
         result.counts.review +
         result.counts.other,
     ).toBe(result.counts.total);
+
+    // `other` here really is the suspended card, but `states` says so
+    // explicitly instead of leaving the caller to guess.
+    expect(result.states).toEqual({
+      new: 3,
+      learning: 0,
+      review: 0,
+      suspended: 1,
+      buried: 0,
+    });
+  });
+
+  it("should surface not-due review cards in states rather than hiding them in `other`", async () => {
+    // Issue #50: a deck of 100 review cards with a daily review limit of 20
+    // reports review=20 and other=80. `other` is NOT suspended/buried here —
+    // it is review cards that simply are not due today.
+    const deckName = "Kanji";
+    const allCardIds = Array.from({ length: 100 }, (_, i) => i + 1);
+
+    ankiClient.invoke.mockImplementation((action: string, params?: any) => {
+      if (action === "deckNamesAndIds") {
+        return Promise.resolve({ [deckName]: 777 });
+      }
+      if (action === "getDeckStats") {
+        return Promise.resolve({
+          "777": {
+            deck_id: 777,
+            name: deckName,
+            new_count: 0,
+            learn_count: 0,
+            review_count: 20, // capped by the daily review limit
+            total_in_deck: 100,
+          },
+        });
+      }
+      if (action === "findCards") {
+        return Promise.resolve(
+          findCardsFor(params.query, allCardIds, { review: allCardIds }),
+        );
+      }
+      if (action === "getEaseFactors")
+        return Promise.resolve(Array(100).fill(2500));
+      if (action === "getIntervals")
+        return Promise.resolve(Array(100).fill(30));
+      return Promise.resolve({});
+    });
+
+    const rawResult = await tool.execute({ deck: deckName });
+    const result = parseToolResult(rawResult) as DeckStatsResult;
+
+    // Study queue: only 20 due today, the other 80 are the residual.
+    expect(result.counts.review).toBe(20);
+    expect(result.counts.other).toBe(80);
+    // True state: all 100 are review cards, nothing is suspended or buried.
+    expect(result.states.review).toBe(100);
+    expect(result.states.suspended).toBe(0);
+    expect(result.states.buried).toBe(0);
   });
 
   it("should roll up child deck totals for parent deck (Bug #3 regression)", async () => {
@@ -269,7 +470,10 @@ describe("DeckStatsTool", () => {
       }
       if (action === "findCards") {
         // `deck:German` matches parent AND children (Anki default)
-        return Promise.resolve(Array.from({ length: 12 }, (_, i) => i + 1));
+        const allCardIds = Array.from({ length: 12 }, (_, i) => i + 1);
+        return Promise.resolve(
+          findCardsFor(params.query, allCardIds, { new: allCardIds }),
+        );
       }
       if (action === "getEaseFactors") {
         return Promise.resolve(Array(12).fill(0));
@@ -299,12 +503,14 @@ describe("DeckStatsTool", () => {
         result.counts.review +
         result.counts.other,
     ).toBe(result.counts.total);
+    // A single `deck:` term already covers the subtree, so states roll up too.
+    expect(result.states.new).toBe(12);
   });
 
   it("should use custom bucket boundaries", async () => {
     const deckName = "Custom Buckets";
 
-    ankiClient.invoke.mockImplementation((action: string) => {
+    ankiClient.invoke.mockImplementation((action: string, params?: any) => {
       if (action === "deckNamesAndIds") {
         return Promise.resolve({ [deckName]: 1234567890 });
       }
@@ -321,7 +527,10 @@ describe("DeckStatsTool", () => {
         });
       }
       if (action === "findCards") {
-        return Promise.resolve(Array.from({ length: 10 }, (_, i) => i + 1));
+        const allCardIds = Array.from({ length: 10 }, (_, i) => i + 1);
+        return Promise.resolve(
+          findCardsFor(params.query, allCardIds, { review: allCardIds }),
+        );
       }
       if (action === "getEaseFactors") {
         return Promise.resolve(Array(10).fill(2000));
@@ -352,7 +561,7 @@ describe("DeckStatsTool", () => {
   it("should correctly divide ease factors by 1000", async () => {
     const deckName = "Ease Factor Test";
 
-    ankiClient.invoke.mockImplementation((action: string) => {
+    ankiClient.invoke.mockImplementation((action: string, params?: any) => {
       if (action === "deckNamesAndIds") {
         return Promise.resolve({ [deckName]: 1234567890 });
       }
@@ -369,7 +578,9 @@ describe("DeckStatsTool", () => {
         });
       }
       if (action === "findCards") {
-        return Promise.resolve([1, 2, 3]);
+        return Promise.resolve(
+          findCardsFor(params.query, [1, 2, 3], { review: [1, 2, 3] }),
+        );
       }
       if (action === "getEaseFactors") {
         return Promise.resolve([4100, 2500, 3000]);
@@ -392,7 +603,7 @@ describe("DeckStatsTool", () => {
   it("should filter out negative intervals (learning cards)", async () => {
     const deckName = "Mixed Intervals";
 
-    ankiClient.invoke.mockImplementation((action: string) => {
+    ankiClient.invoke.mockImplementation((action: string, params?: any) => {
       if (action === "deckNamesAndIds") {
         return Promise.resolve({ [deckName]: 1234567890 });
       }
@@ -409,7 +620,13 @@ describe("DeckStatsTool", () => {
         });
       }
       if (action === "findCards") {
-        return Promise.resolve(Array.from({ length: 15 }, (_, i) => i + 1));
+        const allCardIds = Array.from({ length: 15 }, (_, i) => i + 1);
+        return Promise.resolve(
+          findCardsFor(params.query, allCardIds, {
+            learning: allCardIds.slice(0, 5),
+            review: allCardIds.slice(5),
+          }),
+        );
       }
       if (action === "getEaseFactors") {
         return Promise.resolve(Array(15).fill(2500));
@@ -428,5 +645,7 @@ describe("DeckStatsTool", () => {
 
     expect(result.intervals.count).toBe(10);
     expect(result.intervals.mean).toBe(25);
+    expect(result.states.learning).toBe(5);
+    expect(result.states.review).toBe(10);
   });
 });

--- a/src/mcp/primitives/essential/tools/__tests__/get-cards.tool.spec.ts
+++ b/src/mcp/primitives/essential/tools/__tests__/get-cards.tool.spec.ts
@@ -185,6 +185,42 @@ describe("GetCardsTool", () => {
       });
     });
 
+    it("should escape Anki wildcards so a deck name matches literally", async () => {
+      // `_` and `*` stay active inside double quotes, so an unescaped
+      // "JLPT_N5" would also match a sibling deck named "JLPT-N5".
+      ankiClient.invoke.mockResolvedValueOnce([]);
+
+      await tool.getCards({ deck_name: "JLPT_N5", card_state: "new" });
+
+      expect(ankiClient.invoke).toHaveBeenNthCalledWith(1, "findCards", {
+        query: '"deck:JLPT\\_N5" -is:suspended is:new',
+      });
+    });
+
+    it("should escape backslashes in a deck name", async () => {
+      // Unescaped, `\P` is an invalid escape sequence and AnkiConnect errors.
+      ankiClient.invoke.mockResolvedValueOnce([]);
+
+      await tool.getCards({ deck_name: "Math\\Physics", card_state: "new" });
+
+      expect(ankiClient.invoke).toHaveBeenNthCalledWith(1, "findCards", {
+        query: '"deck:Math\\\\Physics" -is:suspended is:new',
+      });
+    });
+
+    it("should leave :: subdeck separators intact", async () => {
+      ankiClient.invoke.mockResolvedValueOnce([]);
+
+      await tool.getCards({
+        deck_name: "Japanese::JLPT N5",
+        card_state: "new",
+      });
+
+      expect(ankiClient.invoke).toHaveBeenNthCalledWith(1, "findCards", {
+        query: '"deck:Japanese::JLPT N5" -is:suspended is:new',
+      });
+    });
+
     it("should respect the limit parameter", async () => {
       // Arrange
       const manyCardIds = Array.from(

--- a/src/mcp/primitives/essential/tools/__tests__/get-due-cards.tool.spec.ts
+++ b/src/mcp/primitives/essential/tools/__tests__/get-due-cards.tool.spec.ts
@@ -166,6 +166,48 @@ describe("GetDueCardsTool", () => {
       });
     });
 
+    it("should escape Anki wildcards so a deck name matches literally", async () => {
+      // `_` and `*` stay active inside double quotes, so an unescaped
+      // "JLPT_N5" would also match a sibling deck named "JLPT-N5".
+      ankiClient.invoke.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      await tool.getDueCards({ deck_name: "JLPT_N5" });
+
+      expect(ankiClient.invoke).toHaveBeenNthCalledWith(1, "findCards", {
+        query: '"deck:JLPT\\_N5" -is:suspended (is:due OR is:learn)',
+      });
+    });
+
+    it("should escape backslashes in a deck name", async () => {
+      // Unescaped, `\P` is an invalid escape sequence and AnkiConnect errors.
+      ankiClient.invoke.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      await tool.getDueCards({ deck_name: "Math\\Physics" });
+
+      expect(ankiClient.invoke).toHaveBeenNthCalledWith(1, "findCards", {
+        query: '"deck:Math\\\\Physics" -is:suspended (is:due OR is:learn)',
+      });
+    });
+
+    it("should escape the deck name in the new-card count query too", async () => {
+      // The second query built for include_new must use the same escaping.
+      ankiClient.invoke
+        .mockResolvedValueOnce([1])
+        .mockResolvedValueOnce([1])
+        .mockResolvedValueOnce([]);
+
+      await tool.getDueCards({ deck_name: "JLPT_N5", include_new: true });
+
+      const queries = ankiClient.invoke.mock.calls
+        .filter(([action]) => action === "findCards")
+        .map(([, params]) => (params as { query: string }).query);
+
+      expect(queries).toEqual([
+        '"deck:JLPT\\_N5" -is:suspended (is:due OR is:learn OR is:new)',
+        '"deck:JLPT\\_N5" -is:suspended (is:new)',
+      ]);
+    });
+
     it("should respect the limit parameter", async () => {
       // Arrange
       const manyCardIds = Array.from(

--- a/src/mcp/primitives/essential/tools/__tests__/list-decks.tool.spec.ts
+++ b/src/mcp/primitives/essential/tools/__tests__/list-decks.tool.spec.ts
@@ -105,10 +105,12 @@ describe("ListDecksTool", () => {
       "1111111111": {
         deck_id: 1111111111,
         name: "Test",
-        new_count: 0,
-        learn_count: 0,
-        review_count: 0,
-        total_in_deck: 0,
+        // The scheduler rolls a parent's due-tree buckets up over its
+        // children, so the parent mirrors the child's counts here.
+        new_count: 5,
+        learn_count: 2,
+        review_count: 8,
+        total_in_deck: 0, // ...but total_in_deck is own cards only
       },
       "2222222222": {
         deck_id: 2222222222,
@@ -141,11 +143,109 @@ describe("ListDecksTool", () => {
     expect(childDeck.stats.review_count).toBe(8);
     expect(childDeck.stats.name).toBe("Test::STDIO-AddNotes");
 
+    // total_cards sums every deck (own cards only: 0 + 15). The three
+    // scheduler buckets sum ROOT decks only — "Test" already includes
+    // "Test::STDIO-AddNotes", so adding the child again would double them.
     expect(result.summary).toMatchObject({
       total_cards: 15,
       new_cards: 5,
       learning_cards: 2,
       review_cards: 8,
+    });
+  });
+
+  it("should not double-count subdeck cards in the summary buckets", async () => {
+    // Regression: the due-today buckets AnkiConnect returns are already rolled
+    // up over subdecks. Summing every deck row counted each child's cards once
+    // for the child and again for every ancestor — a 3-level tree reported 3x
+    // the real study load.
+    const deckNames = ["German", "German::Verbs", "German::Verbs::Irregular"];
+    const deckNamesAndIds = {
+      German: 1,
+      "German::Verbs": 2,
+      "German::Verbs::Irregular": 3,
+    };
+    // 4 new cards, all of them stored in the deepest deck.
+    const statsResponse = {
+      "1": {
+        deck_id: 1,
+        name: "German",
+        new_count: 4,
+        learn_count: 1,
+        review_count: 2,
+        total_in_deck: 0,
+      },
+      "2": {
+        deck_id: 2,
+        name: "Verbs",
+        new_count: 4,
+        learn_count: 1,
+        review_count: 2,
+        total_in_deck: 0,
+      },
+      "3": {
+        deck_id: 3,
+        name: "Irregular",
+        new_count: 4,
+        learn_count: 1,
+        review_count: 2,
+        total_in_deck: 7,
+      },
+    };
+    ankiClient.invoke
+      .mockResolvedValueOnce(deckNames)
+      .mockResolvedValueOnce(deckNamesAndIds)
+      .mockResolvedValueOnce(statsResponse);
+
+    const rawResult = await tool.execute({ includeStats: true });
+    const result = parseToolResult(rawResult);
+
+    expect(result.summary).toEqual({
+      // Own-card counts, so every row contributes: 0 + 0 + 7.
+      total_cards: 7,
+      // Root deck only — NOT 4 + 4 + 4.
+      new_cards: 4,
+      learning_cards: 1,
+      review_cards: 2,
+    });
+  });
+
+  it("should sum summary buckets across sibling root decks", async () => {
+    // Two independent roots must both contribute — the root-only rule must not
+    // be mistaken for "first deck only".
+    const deckNames = ["German", "Spanish"];
+    const deckNamesAndIds = { German: 1, Spanish: 2 };
+    const statsResponse = {
+      "1": {
+        deck_id: 1,
+        name: "German",
+        new_count: 3,
+        learn_count: 1,
+        review_count: 5,
+        total_in_deck: 10,
+      },
+      "2": {
+        deck_id: 2,
+        name: "Spanish",
+        new_count: 2,
+        learn_count: 4,
+        review_count: 6,
+        total_in_deck: 20,
+      },
+    };
+    ankiClient.invoke
+      .mockResolvedValueOnce(deckNames)
+      .mockResolvedValueOnce(deckNamesAndIds)
+      .mockResolvedValueOnce(statsResponse);
+
+    const rawResult = await tool.execute({ includeStats: true });
+    const result = parseToolResult(rawResult);
+
+    expect(result.summary).toEqual({
+      total_cards: 30,
+      new_cards: 5,
+      learning_cards: 5,
+      review_cards: 11,
     });
   });
 

--- a/src/mcp/primitives/essential/tools/collection-stats/__tests__/collection-stats.tool.spec.ts
+++ b/src/mcp/primitives/essential/tools/collection-stats/__tests__/collection-stats.tool.spec.ts
@@ -1,7 +1,11 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { CollectionStatsTool } from "../collection-stats.tool";
 import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
-import { parseToolResult } from "@/test-fixtures/test-helpers";
+import {
+  CARD_STATE_QUERY_FILTERS,
+  findCardsFor,
+  parseToolResult,
+} from "@/test-fixtures/test-helpers";
 import { CollectionStatsResult } from "../collection-stats.types";
 
 // Mock the AnkiConnectClient
@@ -37,7 +41,9 @@ describe("CollectionStatsTool", () => {
       };
       const deckNames = Object.keys(deckNamesAndIds);
 
-      ankiClient.invoke.mockImplementation((action: string, _params?: any) => {
+      const allCardIds = Array.from({ length: 100 }, (_, i) => i + 1);
+
+      ankiClient.invoke.mockImplementation((action: string, params?: any) => {
         if (action === "deckNamesAndIds") {
           return Promise.resolve(deckNamesAndIds);
         }
@@ -72,8 +78,17 @@ describe("CollectionStatsTool", () => {
         }
 
         if (action === "findCards") {
-          // Total: 35 + 48 + 17 = 100 cards
-          return Promise.resolve(Array.from({ length: 100 }, (_, i) => i + 1));
+          // Total: 35 + 48 + 17 = 100 cards, split by true card state:
+          // 34 new, 10 learning, 50 review, 4 suspended, 2 buried.
+          return Promise.resolve(
+            findCardsFor(params.query, allCardIds, {
+              new: allCardIds.slice(0, 34),
+              learning: allCardIds.slice(34, 44),
+              review: allCardIds.slice(44, 94),
+              suspended: allCardIds.slice(94, 98),
+              buried: allCardIds.slice(98, 100),
+            }),
+          );
         }
 
         if (action === "getEaseFactors") {
@@ -101,7 +116,9 @@ describe("CollectionStatsTool", () => {
       const result = parseToolResult(rawResult) as CollectionStatsResult;
 
       // Assert
-      expect(ankiClient.invoke).toHaveBeenCalledTimes(5);
+      // deckNamesAndIds + getDeckStats + findCards(deck:*) + 5 state queries
+      // + getEaseFactors + getIntervals
+      expect(ankiClient.invoke).toHaveBeenCalledTimes(10);
       expect(ankiClient.invoke).toHaveBeenNthCalledWith(
         1,
         "deckNamesAndIds",
@@ -113,10 +130,17 @@ describe("CollectionStatsTool", () => {
       expect(ankiClient.invoke).toHaveBeenNthCalledWith(3, "findCards", {
         query: "deck:*",
       });
-      expect(ankiClient.invoke).toHaveBeenNthCalledWith(4, "getEaseFactors", {
+      // The state queries are collection-wide (no deck scope) and emitted in
+      // a fixed order.
+      CARD_STATE_QUERY_FILTERS.forEach((filter, i) => {
+        expect(ankiClient.invoke).toHaveBeenNthCalledWith(4 + i, "findCards", {
+          query: filter,
+        });
+      });
+      expect(ankiClient.invoke).toHaveBeenNthCalledWith(9, "getEaseFactors", {
         cards: expect.any(Array),
       });
-      expect(ankiClient.invoke).toHaveBeenNthCalledWith(5, "getIntervals", {
+      expect(ankiClient.invoke).toHaveBeenNthCalledWith(10, "getIntervals", {
         cards: expect.any(Array),
       });
 
@@ -129,6 +153,24 @@ describe("CollectionStatsTool", () => {
         review: 60, // 20 + 30 + 10
         other: 0, // totals match exactly
       });
+
+      // True card-state counts are independent of the due-today buckets above:
+      // 34 new cards exist even though only 30 are queued for today.
+      expect(result.states).toEqual({
+        new: 34,
+        learning: 10,
+        review: 50,
+        suspended: 4,
+        buried: 2,
+      });
+      // The five states partition the collection.
+      expect(
+        result.states.new +
+          result.states.learning +
+          result.states.review +
+          result.states.suspended +
+          result.states.buried,
+      ).toBe(100);
 
       // Check distributions
       expect(result.ease.count).toBe(70); // Filtered out zeros
@@ -156,7 +198,7 @@ describe("CollectionStatsTool", () => {
         Spanish: 1651445861967,
       };
 
-      ankiClient.invoke.mockImplementation((action: string) => {
+      ankiClient.invoke.mockImplementation((action: string, params?: any) => {
         if (action === "deckNamesAndIds") {
           return Promise.resolve(deckNamesAndIds);
         }
@@ -176,7 +218,11 @@ describe("CollectionStatsTool", () => {
         }
 
         if (action === "findCards") {
-          return Promise.resolve([101, 102, 103]);
+          return Promise.resolve(
+            findCardsFor(params.query, [101, 102, 103], {
+              new: [101, 102, 103],
+            }),
+          );
         }
 
         if (action === "getEaseFactors") {
@@ -223,7 +269,7 @@ describe("CollectionStatsTool", () => {
       // missing card is suspended/buried and should land in `other`.
       const deckNamesAndIds = { Spanish: 1651445861967 };
 
-      ankiClient.invoke.mockImplementation((action: string) => {
+      ankiClient.invoke.mockImplementation((action: string, params?: any) => {
         if (action === "deckNamesAndIds") {
           return Promise.resolve(deckNamesAndIds);
         }
@@ -242,7 +288,12 @@ describe("CollectionStatsTool", () => {
         }
 
         if (action === "findCards") {
-          return Promise.resolve([1, 2, 3, 4]);
+          return Promise.resolve(
+            findCardsFor(params.query, [1, 2, 3, 4], {
+              new: [1, 2, 3],
+              suspended: [4],
+            }),
+          );
         }
 
         if (action === "getEaseFactors") {
@@ -282,6 +333,66 @@ describe("CollectionStatsTool", () => {
         review: 0,
         other: 1,
       });
+
+      // `states` names the residual instead of leaving it to guesswork.
+      expect(result.states).toEqual({
+        new: 3,
+        learning: 0,
+        review: 0,
+        suspended: 1,
+        buried: 0,
+      });
+    });
+
+    it("should surface not-due review cards in states rather than hiding them in `other`", async () => {
+      // Issue #50: 100 review cards with a daily review limit of 20 report
+      // review=20 and other=80. Nothing is suspended or buried — `other` is
+      // simply review cards that are not due today.
+      const allCardIds = Array.from({ length: 100 }, (_, i) => i + 1);
+
+      ankiClient.invoke.mockImplementation((action: string, params?: any) => {
+        if (action === "deckNamesAndIds") {
+          return Promise.resolve({ Kanji: 777 });
+        }
+
+        if (action === "getDeckStats") {
+          return Promise.resolve({
+            "777": {
+              deck_id: 777,
+              name: "Kanji",
+              new_count: 0,
+              learn_count: 0,
+              review_count: 20, // capped by the daily review limit
+              total_in_deck: 100,
+            },
+          });
+        }
+
+        if (action === "findCards") {
+          return Promise.resolve(
+            findCardsFor(params.query, allCardIds, { review: allCardIds }),
+          );
+        }
+
+        if (action === "getEaseFactors") {
+          return Promise.resolve(Array(100).fill(2500));
+        }
+
+        if (action === "getIntervals") {
+          return Promise.resolve(Array(100).fill(30));
+        }
+
+        return Promise.resolve({});
+      });
+
+      const rawResult = await tool.execute({});
+      const result = parseToolResult(rawResult) as CollectionStatsResult;
+
+      expect(result.counts.review).toBe(20);
+      expect(result.counts.other).toBe(80);
+      expect(result.states.review).toBe(100);
+      expect(result.states.suspended).toBe(0);
+      expect(result.states.buried).toBe(0);
     });
 
     it("should roll up parent::child counts without double-counting (Bug #3 regression)", async () => {
@@ -293,7 +404,7 @@ describe("CollectionStatsTool", () => {
       // ROOT decks only (German) to avoid counting German::Verbs twice.
       const parentId = 5000000001;
       const childId = 5000000002;
-      ankiClient.invoke.mockImplementation((action: string) => {
+      ankiClient.invoke.mockImplementation((action: string, params?: any) => {
         if (action === "deckNamesAndIds") {
           return Promise.resolve({
             German: parentId,
@@ -323,7 +434,10 @@ describe("CollectionStatsTool", () => {
         }
 
         if (action === "findCards") {
-          return Promise.resolve(Array.from({ length: 12 }, (_, i) => i + 1));
+          const allCardIds = Array.from({ length: 12 }, (_, i) => i + 1);
+          return Promise.resolve(
+            findCardsFor(params.query, allCardIds, { new: allCardIds }),
+          );
         }
 
         if (action === "getEaseFactors") {
@@ -379,6 +493,10 @@ describe("CollectionStatsTool", () => {
         other: 0,
       });
       expect(result.counts.new).toBeLessThanOrEqual(result.counts.total);
+
+      // `states` is collection-wide and search-based, so subdeck rollup and
+      // double-counting simply do not apply.
+      expect(result.states.new).toBe(12);
     });
 
     it("should handle no decks in collection", async () => {
@@ -405,6 +523,13 @@ describe("CollectionStatsTool", () => {
       });
       expect(result.ease.count).toBe(0);
       expect(result.intervals.count).toBe(0);
+      expect(result.states).toEqual({
+        new: 0,
+        learning: 0,
+        review: 0,
+        suspended: 0,
+        buried: 0,
+      });
       expect(result.per_deck).toEqual([]);
 
       // Should only call deckNamesAndIds
@@ -419,7 +544,7 @@ describe("CollectionStatsTool", () => {
         "Empty Deck": 2,
       };
 
-      ankiClient.invoke.mockImplementation((action: string) => {
+      ankiClient.invoke.mockImplementation((action: string, params?: any) => {
         if (action === "deckNamesAndIds") {
           return Promise.resolve(deckNamesAndIds);
         }
@@ -446,7 +571,10 @@ describe("CollectionStatsTool", () => {
         }
 
         if (action === "findCards") {
-          return Promise.resolve(Array.from({ length: 30 }, (_, i) => i + 1));
+          const allCardIds = Array.from({ length: 30 }, (_, i) => i + 1);
+          return Promise.resolve(
+            findCardsFor(params.query, allCardIds, { review: allCardIds }),
+          );
         }
 
         if (action === "getEaseFactors") {
@@ -485,7 +613,7 @@ describe("CollectionStatsTool", () => {
       // Arrange
       const deckNamesAndIds = { Math: 1, Science: 2 };
 
-      ankiClient.invoke.mockImplementation((action: string) => {
+      ankiClient.invoke.mockImplementation((action: string, params?: any) => {
         if (action === "deckNamesAndIds") {
           return Promise.resolve(deckNamesAndIds);
         }
@@ -512,7 +640,10 @@ describe("CollectionStatsTool", () => {
         }
 
         if (action === "findCards") {
-          return Promise.resolve(Array.from({ length: 101 }, (_, i) => i + 1));
+          const allCardIds = Array.from({ length: 101 }, (_, i) => i + 1);
+          return Promise.resolve(
+            findCardsFor(params.query, allCardIds, { review: allCardIds }),
+          );
         }
 
         if (action === "getEaseFactors") {
@@ -566,7 +697,7 @@ describe("CollectionStatsTool", () => {
       const customEaseBuckets = [1.8, 2.2, 2.8];
       const customIntervalBuckets = [10, 30, 60];
 
-      ankiClient.invoke.mockImplementation((action: string) => {
+      ankiClient.invoke.mockImplementation((action: string, params?: any) => {
         if (action === "deckNamesAndIds") {
           return Promise.resolve({ "Test Deck": 1 });
         }
@@ -585,7 +716,10 @@ describe("CollectionStatsTool", () => {
         }
 
         if (action === "findCards") {
-          return Promise.resolve([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+          const allCardIds = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+          return Promise.resolve(
+            findCardsFor(params.query, allCardIds, { review: allCardIds }),
+          );
         }
 
         if (action === "getEaseFactors") {
@@ -624,6 +758,10 @@ describe("CollectionStatsTool", () => {
             "Empty Deck 1": 1,
             "Empty Deck 2": 2,
           });
+        }
+
+        if (action === "findCards") {
+          return Promise.resolve([]);
         }
 
         if (action === "getDeckStats") {
@@ -665,15 +803,24 @@ describe("CollectionStatsTool", () => {
       });
       expect(result.ease.count).toBe(0);
       expect(result.intervals.count).toBe(0);
+      expect(result.states).toEqual({
+        new: 0,
+        learning: 0,
+        review: 0,
+        suspended: 0,
+        buried: 0,
+      });
       expect(result.per_deck).toHaveLength(2);
 
-      // Should not call findCards, getEaseFactors, or getIntervals
-      expect(ankiClient.invoke).toHaveBeenCalledTimes(2); // Only deckNamesAndIds and getDeckStats
+      // Emptiness is decided by the `deck:*` search, never by total_in_deck:
+      // deckNamesAndIds + getDeckStats + findCards, then short-circuit before
+      // the state queries, getEaseFactors and getIntervals.
+      expect(ankiClient.invoke).toHaveBeenCalledTimes(3);
     });
 
     it("should correctly divide ease factors by 1000", async () => {
       // Arrange
-      ankiClient.invoke.mockImplementation((action: string) => {
+      ankiClient.invoke.mockImplementation((action: string, params?: any) => {
         if (action === "deckNamesAndIds") {
           return Promise.resolve({ Test: 1 });
         }
@@ -692,7 +839,9 @@ describe("CollectionStatsTool", () => {
         }
 
         if (action === "findCards") {
-          return Promise.resolve([1, 2, 3]);
+          return Promise.resolve(
+            findCardsFor(params.query, [1, 2, 3], { review: [1, 2, 3] }),
+          );
         }
 
         if (action === "getEaseFactors") {
@@ -720,7 +869,7 @@ describe("CollectionStatsTool", () => {
 
     it("should filter out negative intervals", async () => {
       // Arrange
-      ankiClient.invoke.mockImplementation((action: string) => {
+      ankiClient.invoke.mockImplementation((action: string, params?: any) => {
         if (action === "deckNamesAndIds") {
           return Promise.resolve({ Test: 1 });
         }
@@ -739,7 +888,13 @@ describe("CollectionStatsTool", () => {
         }
 
         if (action === "findCards") {
-          return Promise.resolve(Array.from({ length: 15 }, (_, i) => i + 1));
+          const allCardIds = Array.from({ length: 15 }, (_, i) => i + 1);
+          return Promise.resolve(
+            findCardsFor(params.query, allCardIds, {
+              learning: allCardIds.slice(0, 5),
+              review: allCardIds.slice(5),
+            }),
+          );
         }
 
         if (action === "getEaseFactors") {
@@ -764,6 +919,8 @@ describe("CollectionStatsTool", () => {
       // Assert - only positive intervals counted
       expect(result.intervals.count).toBe(10);
       expect(result.intervals.mean).toBe(30);
+      expect(result.states.learning).toBe(5);
+      expect(result.states.review).toBe(10);
     });
 
     it("should handle AnkiConnect errors gracefully", async () => {
@@ -817,6 +974,61 @@ describe("CollectionStatsTool", () => {
       expect(result.counts.total).toBe(10);
       expect(result.ease.count).toBe(0);
       expect(result.intervals.count).toBe(0);
+      expect(result.states).toEqual({
+        new: 0,
+        learning: 0,
+        review: 0,
+        suspended: 0,
+        buried: 0,
+      });
+      // Short-circuits before the state queries.
+      expect(ankiClient.invoke).toHaveBeenCalledTimes(3);
+    });
+
+    it("should trust the deck search over total_in_deck when a filtered deck borrowed the cards", async () => {
+      // getDeckStats reports total_in_deck: 0 because the cards sit in a
+      // filtered deck's row, but `deck:*` still matches them. Short-circuiting
+      // on counts.total would report all-zero states, i.e. lie.
+      ankiClient.invoke.mockImplementation((action: string, params?: any) => {
+        if (action === "deckNamesAndIds") {
+          return Promise.resolve({ Loaned: 99 });
+        }
+
+        if (action === "getDeckStats") {
+          return Promise.resolve({
+            "99": {
+              deck_id: 99,
+              name: "Loaned",
+              new_count: 0,
+              learn_count: 0,
+              review_count: 0,
+              total_in_deck: 0,
+            },
+          });
+        }
+
+        if (action === "findCards") {
+          return Promise.resolve(
+            findCardsFor(params.query, [1, 2, 3, 4], { review: [1, 2, 3, 4] }),
+          );
+        }
+
+        if (action === "getEaseFactors") {
+          return Promise.resolve(Array(4).fill(2500));
+        }
+
+        if (action === "getIntervals") {
+          return Promise.resolve(Array(4).fill(10));
+        }
+
+        return Promise.resolve({});
+      });
+
+      const rawResult = await tool.execute({});
+      const result = parseToolResult(rawResult) as CollectionStatsResult;
+
+      expect(result.counts.total).toBe(0);
+      expect(result.states.review).toBe(4);
     });
   });
 });

--- a/src/mcp/primitives/essential/tools/collection-stats/collection-stats.tool.ts
+++ b/src/mcp/primitives/essential/tools/collection-stats/collection-stats.tool.ts
@@ -5,6 +5,14 @@ import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
 import type { AnkiDeckStatsResponse } from "@/mcp/types/anki.types";
 import { createErrorResponse } from "@/mcp/utils/anki.utils";
 import {
+  cardStatesSchema,
+  DUE_TREE_INVARIANT_NOTE,
+  dueTreeCountsSchema,
+  dueTreeCountsShape,
+  emptyCardStateCounts,
+  fetchCardStateCounts,
+} from "@/mcp/utils/card-states.utils";
+import {
   getRootDeckNames,
   rollupDeckTotal,
 } from "@/mcp/utils/deck-hierarchy.utils";
@@ -28,10 +36,13 @@ export class CollectionStatsTool {
     name: "collection_stats",
     description:
       "Get aggregated statistics across all decks in the collection including card counts, ease factor distribution, and interval distribution. " +
-      "Per-deck counts are rolled up over descendants (a parent deck includes its children), matching Anki's deck browser. " +
-      "Collection-level `counts` sum the ROOT decks only to avoid double-counting children. " +
-      "Invariant: for every deck and for the collection, total === new + learning + review + other. " +
-      "Use this to analyze overall collection health and compare deck statistics. " +
+      "Returns TWO different views, do not mix them up: " +
+      "`counts` and `per_deck` are today's study queue as shown in Anki's deck browser (cards DUE TODAY, capped by each deck's daily new/review limits, suspended/buried excluded); " +
+      "`states` is the true number of cards in each state (new / learning / review / suspended / buried) across the whole collection, ignoring due dates and daily limits. " +
+      'To answer "how many cards do I have" use `states`; to answer "what will I study today" use `counts`. ' +
+      "Per-deck counts are rolled up over descendants (a parent deck includes its children); collection-level `counts` sum the ROOT decks only to avoid double-counting children. " +
+      "`states` is collection-wide only (it costs 5 additional Anki searches per call) — call the `deckStats` tool for a single deck's true state counts. " +
+      `For every deck and for the collection: ${DUE_TREE_INVARIANT_NOTE} ` +
       "Ease buckets and interval buckets can be customized to focus on specific ranges.",
     parameters: z.object({
       ease_buckets: z
@@ -69,44 +80,17 @@ export class CollectionStatsTool {
     }),
     outputSchema: z.object({
       total_decks: z.number(),
-      counts: z
-        .object({
-          total: z
-            .number()
-            .describe(
-              "Total cards in the collection. Computed as the sum of " +
-                "ROOT-deck rolled-up totals (decks without `::` in the name), " +
-                "which prevents double-counting children. Invariant: " +
-                "total === new + learning + review + other.",
-            ),
-          new: z
-            .number()
-            .describe(
-              "New cards (never studied), summed over root decks' rolled-up counts.",
-            ),
-          learning: z
-            .number()
-            .describe(
-              "Learning/relearning cards, summed over root decks' rolled-up counts.",
-            ),
-          review: z
-            .number()
-            .describe(
-              "Review cards (mature), summed over root decks' rolled-up counts.",
-            ),
-          other: z
-            .number()
-            .describe(
-              "Cards not in new/learning/review (typically suspended or buried), " +
-                "summed over root decks' rolled-up counts. " +
-                "Computed as total - new - learning - review.",
-            ),
-        })
-        .describe(
-          "Aggregated card counts across the collection. Summed over ROOT " +
-            "decks only (names without `::`) so that a parent's rollup is not " +
-            "added on top of its children.",
-        ),
+      counts: dueTreeCountsSchema({
+        scope: "the whole collection",
+        total:
+          "Total cards in the collection, including suspended and buried. " +
+          "Computed as the sum of ROOT-deck rolled-up totals (decks without " +
+          "`::` in the name), which prevents double-counting children.",
+        note:
+          "Summed over ROOT decks only (names without `::`) so that a " +
+          "parent's rollup is not added on top of its children.",
+      }),
+      states: cardStatesSchema("the whole collection"),
       ease: z.object({
         mean: z.number(),
         median: z.number(),
@@ -126,19 +110,22 @@ export class CollectionStatsTool {
       per_deck: z
         .array(
           z.object({
-            deck: z.string(),
-            total: z.number(),
-            new: z.number(),
-            learning: z.number(),
-            review: z.number(),
-            other: z.number(),
+            deck: z.string().describe('Full deck name, e.g. "German::Verbs".'),
+            ...dueTreeCountsShape(
+              "Total cards in this deck AND all of its descendants, " +
+                "including suspended and buried.",
+            ),
           }),
         )
         .describe(
-          "Per-deck breakdown with one entry per deck. Each entry's counts " +
-            'are rolled up over that deck\'s descendants (entry for "German" ' +
-            'includes cards from "German::Verbs"). Invariant per row: ' +
-            "total === new + learning + review + other.",
+          "Per-deck breakdown of today's study queue — same due-today, " +
+            "daily-limit-capped semantics as `counts`, NOT card totals. One " +
+            "entry per deck; each entry's counts are rolled up over that " +
+            'deck\'s descendants (entry for "German" includes cards from ' +
+            '"German::Verbs"). Normally total === new + learning + review + ' +
+            "other per row, but `other` is clamped at 0 so the sum can exceed " +
+            "total in rare filtered-deck cases. Per-deck true state counts are " +
+            "not included here — call the `deckStats` tool for a specific deck.",
         ),
     }),
     annotations: {
@@ -177,6 +164,7 @@ export class CollectionStatsTool {
             review: 0,
             other: 0,
           },
+          states: emptyCardStateCounts(),
           ease: computeDistribution([], { boundaries: ease_buckets }),
           intervals: computeDistribution([], {
             boundaries: interval_buckets,
@@ -287,22 +275,12 @@ export class CollectionStatsTool {
           `(${deckNames.length} total decks including children)`,
       );
 
-      // Handle empty collection case
-      if (counts.total === 0) {
-        this.logger.log("Collection is empty (no cards)");
-        const result: CollectionStatsResult = {
-          total_decks: deckNames.length,
-          counts,
-          ease: computeDistribution([], { boundaries: ease_buckets }),
-          intervals: computeDistribution([], {
-            boundaries: interval_buckets,
-            unitSuffix: "d",
-          }),
-          per_deck,
-        };
-
-        return result;
-      }
+      // NOTE: deliberately no `counts.total === 0` short-circuit. `total` is
+      // summed from `total_in_deck`, the storage-deck row count this tool
+      // cannot trust — cards borrowed by a filtered deck can make it read 0
+      // while `deck:*` still matches them. The `findCards` result below is the
+      // single emptiness gate, derived from the same search the state counts
+      // use.
 
       // Step 3: Get all card IDs across the entire collection
       this.logger.log("Finding all cards in collection...");
@@ -311,12 +289,13 @@ export class CollectionStatsTool {
       });
 
       if (!cardIds || cardIds.length === 0) {
-        this.logger.warn(
-          "No cards found via findCards, using counts from getDeckStats",
+        this.logger.log(
+          "No cards found via findCards; reporting getDeckStats counts with zeroed states",
         );
         const result: CollectionStatsResult = {
           total_decks: deckNames.length,
           counts,
+          states: emptyCardStateCounts(),
           ease: computeDistribution([], { boundaries: ease_buckets }),
           intervals: computeDistribution([], {
             boundaries: interval_buckets,
@@ -330,7 +309,19 @@ export class CollectionStatsTool {
 
       this.logger.log(`Found ${cardIds.length} cards in collection`);
 
-      // Step 4: Get ease factors for all cards (divide by 1000!)
+      // Step 4: True card-state counts for the whole collection (5 findCards
+      // queries). `counts` above is the scheduler's due-today view and cannot
+      // answer "how many cards are new/suspended/..." — this can. Deliberately
+      // collection-wide only: per-deck states would cost 5 queries per deck.
+      this.logger.log("Counting cards by state...");
+      const states = await fetchCardStateCounts(this.ankiClient);
+      this.logger.log(
+        `Card states: ${states.new} new, ${states.learning} learning, ` +
+          `${states.review} review, ${states.suspended} suspended, ` +
+          `${states.buried} buried`,
+      );
+
+      // Step 5: Get ease factors for all cards (divide by 1000!)
       this.logger.log(`Fetching ease factors for ${cardIds.length} cards...`);
       const easeFactorsRaw = await this.ankiClient.invoke<number[]>(
         "getEaseFactors",
@@ -350,7 +341,7 @@ export class CollectionStatsTool {
 
       this.logger.log(`Processed ${easeValues.length} ease values`);
 
-      // Step 5: Get intervals for all cards (filter negatives!)
+      // Step 6: Get intervals for all cards (filter negatives!)
       this.logger.log(`Fetching intervals for ${cardIds.length} cards...`);
       const intervalsRaw = await this.ankiClient.invoke<number[]>(
         "getIntervals",
@@ -368,7 +359,7 @@ export class CollectionStatsTool {
 
       this.logger.log(`Processed ${intervalValues.length} interval values`);
 
-      // Step 6: Compute distributions
+      // Step 7: Compute distributions
       this.logger.log("Computing distributions...");
       const ease = computeDistribution(easeValues, {
         boundaries: ease_buckets,
@@ -382,6 +373,7 @@ export class CollectionStatsTool {
       const result: CollectionStatsResult = {
         total_decks: deckNames.length,
         counts,
+        states,
         ease,
         intervals,
         per_deck,

--- a/src/mcp/primitives/essential/tools/collection-stats/collection-stats.types.ts
+++ b/src/mcp/primitives/essential/tools/collection-stats/collection-stats.types.ts
@@ -1,3 +1,7 @@
+import type {
+  CardStateCounts,
+  DueTreeCounts,
+} from "@/mcp/utils/card-states.utils";
 import { DistributionMetrics } from "@/mcp/utils/stats.utils";
 
 /**
@@ -12,35 +16,31 @@ export interface CollectionStatsParams {
 }
 
 /**
- * Per-deck breakdown structure.
+ * Per-deck breakdown structure — today's study queue, NOT card totals. See
+ * {@link DueTreeCounts} for the full semantics of each count field.
  *
- * All count fields are rolled up over the deck and its descendants so the
- * breakdown matches Anki's deck browser: a row for `"German"` includes
- * cards from `"German::Verbs"`. Invariant: `total === new + learning + review + other`.
+ * All fields are rolled up over the deck and its descendants, so a row for
+ * `"German"` includes cards from `"German::Verbs"`.
+ *
+ * True per-state counts are only reported collection-wide (see
+ * {@link CollectionStatsResult.states}); per-deck state counts would cost five
+ * extra queries per deck and are intentionally not included. Call the
+ * `deckStats` tool for a single deck's `states`.
  */
-export interface PerDeckStats {
+export interface PerDeckStats extends DueTreeCounts {
   /** Deck name */
   deck: string;
-  /**
-   * Total cards in this deck AND all of its descendants
-   * (e.g. row for `"German"` includes cards in `"German::Verbs"`).
-   */
-  total: number;
-  /** New cards (never studied), rolled up over descendants */
-  new: number;
-  /** Learning/relearning cards, rolled up over descendants */
-  learning: number;
-  /** Review cards (mature), rolled up over descendants */
-  review: number;
-  /**
-   * Cards not in new/learning/review (typically suspended or buried),
-   * rolled up over descendants. Computed as `total - new - learning - review`.
-   */
-  other: number;
 }
 
 /**
  * Result structure for collection_stats tool.
+ *
+ * Two different views, deliberately kept apart:
+ *
+ * - `counts` / `per_deck` — today's **study queue** from the scheduler's due
+ *   tree: due-today only, capped by daily limits. Anki's deck browser numbers.
+ * - `states` — true **card-state** counts across the whole collection, from
+ *   Anki searches. No due-date filter, no daily limits.
  *
  * `counts` aggregates ROOT decks only (names without `::`) so children
  * aren't double-counted — each root's per-deck entry is already rolled up
@@ -51,26 +51,22 @@ export interface CollectionStatsResult {
   total_decks: number;
 
   /**
-   * Aggregated card counts across the collection. Summed over ROOT decks
-   * only (names without `::`) so a parent's rollup is not added on top of
-   * its children. Invariant: `total === new + learning + review + other`.
+   * Today's study queue across the collection — NOT card totals. See
+   * {@link DueTreeCounts} for the full semantics of each field.
+   *
+   * Summed over ROOT decks only (names without `::`) so a parent's rollup is
+   * not added on top of its children.
+   *
+   * Use {@link CollectionStatsResult.states} for "how many cards are in state X".
    */
-  counts: {
-    /** Total cards in collection (sum of root decks' rolled-up totals) */
-    total: number;
-    /** New cards (never studied), summed over root decks' rolled-up counts */
-    new: number;
-    /** Learning/relearning cards, summed over root decks' rolled-up counts */
-    learning: number;
-    /** Review cards (mature), summed over root decks' rolled-up counts */
-    review: number;
-    /**
-     * Cards not in new/learning/review (typically suspended or buried),
-     * summed over root decks' rolled-up counts.
-     * Computed as `total - new - learning - review`.
-     */
-    other: number;
-  };
+  counts: DueTreeCounts;
+
+  /**
+   * True card-state counts across the whole collection, from Anki searches.
+   * Unaffected by due dates and daily limits. The five values are mutually
+   * exclusive and together cover every card in the collection.
+   */
+  states: CardStateCounts;
 
   /** Ease factor distribution (only for cards with ease values) */
   ease: DistributionMetrics;
@@ -79,10 +75,11 @@ export interface CollectionStatsResult {
   intervals: DistributionMetrics;
 
   /**
-   * Per-deck breakdown of card counts. One entry per deck returned by
-   * `deckNames` (includes children). Each entry's counts are rolled up over
-   * that deck's descendants; invariant per row:
-   * `total === new + learning + review + other`.
+   * Per-deck breakdown of today's study queue (same semantics as `counts`).
+   * One entry per deck returned by `deckNames` (includes children). Each
+   * entry's counts are rolled up over that deck's descendants; per row,
+   * normally `total === new + learning + review + other`, with the same
+   * clamping caveat as {@link CollectionStatsResult.counts}.
    */
   per_deck: PerDeckStats[];
 }

--- a/src/mcp/primitives/essential/tools/deck-stats.tool.ts
+++ b/src/mcp/primitives/essential/tools/deck-stats.tool.ts
@@ -3,6 +3,11 @@ import { Tool } from "@rekog/mcp-nest";
 import { z } from "zod";
 import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
 import { createErrorResponse } from "@/mcp/utils/anki.utils";
+import {
+  cardStatesSchema,
+  DUE_TREE_INVARIANT_NOTE,
+  dueTreeCountsSchema,
+} from "@/mcp/utils/card-states.utils";
 import { deckStats } from "./deckActions/actions/deckStats.action";
 
 @Injectable()
@@ -15,8 +20,13 @@ export class DeckStatsTool {
     name: "deckStats",
     description:
       'Get comprehensive statistics for a single deck including card counts, ease and interval distributions. Pass a deck name (e.g., "Japanese::JLPT N5") and optional bucket boundaries. ' +
-      "Counts are rolled up over descendant decks (parent decks include their children), matching Anki's deck browser. " +
-      "Invariant: total === new + learning + review + other.",
+      "Returns TWO different views, do not mix them up: " +
+      "`counts` is today's study queue as shown in Anki's deck browser (cards DUE TODAY, capped by the deck's daily new/review limits, suspended/buried excluded); " +
+      "`states` is the true number of cards in each state (new / learning / review / suspended / buried), ignoring due dates and daily limits. " +
+      'To answer "how many cards do I have" use `states`; to answer "what will I study today" use `counts`. ' +
+      "Both are rolled up over descendant decks (parent decks include their children). " +
+      "`states` costs 5 additional Anki searches per call. " +
+      `For counts: ${DUE_TREE_INVARIANT_NOTE}`,
     parameters: z.object({
       deck: z.string().describe('Deck name (e.g., "Japanese::JLPT N5")'),
       easeBuckets: z
@@ -37,43 +47,15 @@ export class DeckStatsTool {
     outputSchema: z.object({
       success: z.boolean(),
       deck: z.string(),
-      counts: z
-        .object({
-          total: z
-            .number()
-            .describe(
-              "Total cards in this deck AND all of its descendants. " +
-                'Example: stats for "German" include cards in "German::Verbs" ' +
-                'and "German::Verbs::Irregular". Invariant: ' +
-                "total === new + learning + review + other.",
-            ),
-          new: z
-            .number()
-            .describe(
-              "New cards (never studied), rolled up over descendant decks.",
-            ),
-          learning: z
-            .number()
-            .describe(
-              "Learning/relearning cards, rolled up over descendant decks.",
-            ),
-          review: z
-            .number()
-            .describe(
-              "Review cards (mature), rolled up over descendant decks.",
-            ),
-          other: z
-            .number()
-            .describe(
-              "Cards not in new/learning/review (typically suspended or buried), " +
-                "rolled up over descendant decks. " +
-                "Computed as total - new - learning - review.",
-            ),
-        })
-        .describe(
-          "Card counts rolled up over the deck and all of its descendants. " +
-            "Matches Anki's deck browser behaviour for parent decks.",
-        ),
+      counts: dueTreeCountsSchema({
+        scope: "this deck and all of its descendants",
+        total:
+          "Total cards in this deck AND all of its descendants, including " +
+          'suspended and buried. Example: stats for "German" include cards in ' +
+          '"German::Verbs" and "German::Verbs::Irregular".',
+        note: "All four bucket counts are rolled up over descendant decks.",
+      }),
+      states: cardStatesSchema("this deck and all of its subdecks"),
       ease: z.object({
         mean: z.number(),
         median: z.number(),

--- a/src/mcp/primitives/essential/tools/deckActions/actions/deckStats.action.ts
+++ b/src/mcp/primitives/essential/tools/deckActions/actions/deckStats.action.ts
@@ -5,6 +5,13 @@ import {
   DistributionMetrics,
 } from "@/mcp/utils/stats.utils";
 import { isDescendantOf } from "@/mcp/utils/deck-hierarchy.utils";
+import {
+  deckScopeQuery,
+  emptyCardStateCounts,
+  fetchCardStateCounts,
+  type CardStateCounts,
+  type DueTreeCounts,
+} from "@/mcp/utils/card-states.utils";
 
 /**
  * Parameters for deckStats action
@@ -23,9 +30,16 @@ export interface DeckStatsParams {
 /**
  * Result structure for deckStats action.
  *
- * All `counts` fields roll up descendants: a stat for `"German"` covers
- * `"German"` + `"German::Verbs"` + `"German::Verbs::Irregular"` etc., matching
- * how the Anki UI displays parent decks.
+ * Two different views of the same deck, deliberately kept apart:
+ *
+ * - `counts` — today's **study queue**, straight from AnkiConnect's
+ *   `getDeckStats` (the scheduler due tree). Due-today only and capped by daily
+ *   limits. These are the numbers Anki's deck browser shows.
+ * - `states` — true **card-state** counts from Anki searches. No due-date
+ *   filter, no daily limits.
+ *
+ * Both views roll up descendants: stats for `"German"` cover `"German"` +
+ * `"German::Verbs"` + `"German::Verbs::Irregular"` etc.
  */
 export interface DeckStatsResult {
   /** Whether the operation succeeded */
@@ -35,29 +49,20 @@ export interface DeckStatsResult {
   deck: string;
 
   /**
-   * Card counts by status. All values are rolled up over the deck and all of
-   * its descendants (matches Anki UI convention for parent decks).
-   * Invariant: `total === new + learning + review + other`.
+   * Today's study queue for this deck and all of its descendants, as shown in
+   * Anki's deck browser — NOT card totals. See {@link DueTreeCounts} for the
+   * full semantics of each field.
+   *
+   * Use {@link DeckStatsResult.states} for "how many cards are in state X".
    */
-  counts: {
-    /**
-     * Total cards in this deck AND all of its descendants
-     * (e.g. stats for `"German"` include cards in `"German::Verbs"`).
-     */
-    total: number;
-    /** New cards (never studied), rolled up over descendants */
-    new: number;
-    /** Learning/relearning cards, rolled up over descendants */
-    learning: number;
-    /** Review cards (mature), rolled up over descendants */
-    review: number;
-    /**
-     * Cards not in new/learning/review (typically suspended or buried),
-     * rolled up over descendants. Computed as
-     * `total - new - learning - review`.
-     */
-    other: number;
-  };
+  counts: DueTreeCounts;
+
+  /**
+   * True card-state counts for this deck and its subdecks, from Anki searches.
+   * Unaffected by due dates and daily limits. The five values are mutually
+   * exclusive and together cover every card matched by `deck:<name>`.
+   */
+  states: CardStateCounts;
 
   /** Ease factor distribution (only for cards with ease values) */
   ease: DistributionMetrics;
@@ -72,16 +77,23 @@ export interface DeckStatsResult {
 export type ProgressCallback = (progress: number) => Promise<void>;
 
 /**
- * Get comprehensive statistics for a single deck including card counts,
- * ease factor distribution, and interval distribution.
+ * Get comprehensive statistics for a single deck: today's study queue
+ * (`counts`), true card-state counts (`states`), and ease/interval
+ * distributions.
  *
- * Counts are rolled up over descendant decks (e.g. `"German"` includes
- * cards from `"German::Verbs"`). This matches how AnkiConnect reports
- * scheduler buckets for parent decks and how the Anki UI displays them.
- * Without this rollup, `total_in_deck` (direct cards only) would be
- * inconsistent with `new_count` / `learn_count` / `review_count`
- * (descendants included), producing nonsense like `new > total`.
+ * `counts` mirrors Anki's deck browser — due-today numbers capped by daily
+ * limits — while `states` answers "how many cards are in state X" via searches.
+ * Keeping both is deliberate: neither can be derived from the other.
  *
+ * Both are rolled up over descendant decks (e.g. `"German"` includes cards from
+ * `"German::Verbs"`). For `counts` this matches how AnkiConnect reports
+ * scheduler buckets for parent decks; without rolling up `total_in_deck`
+ * (direct cards only) it would be inconsistent with `new_count` /
+ * `learn_count` / `review_count` (descendants included), producing nonsense
+ * like `new > total`. For `states` the rollup is free — Anki's `deck:` search
+ * includes subdecks by default.
+ *
+ * @see https://docs.ankiweb.net/searching.html#card-state
  * @see https://git.sr.ht/~foosoft/anki-connect#getdeckstats
  * @see https://git.sr.ht/~foosoft/anki-connect#findcards
  * @see https://git.sr.ht/~foosoft/anki-connect#geteasefactors
@@ -149,9 +161,12 @@ export async function deckStats(
     total += descStats?.total_in_deck ?? 0;
   }
 
-  // Anything not in the three scheduler buckets (typically suspended or
-  // buried cards) lands in `other`. Clamp to zero in the pathological case
-  // where AnkiConnect's counts disagree with its own card listing.
+  // `other` is a residual, not a card state: the three buckets above only
+  // count cards DUE TODAY and are capped by the deck's daily limits, while
+  // `total` counts every card. So `other` is dominated by review cards not due
+  // today and new cards beyond the daily new limit; suspended and buried cards
+  // land here too. Clamp to zero in the pathological case where AnkiConnect's
+  // counts disagree with its own card listing.
   const other = Math.max(0, total - newCount - learning - review);
 
   const counts = {
@@ -164,32 +179,33 @@ export async function deckStats(
 
   await onProgress?.(30);
 
-  // Handle empty deck case
-  if (counts.total === 0) {
-    return {
-      success: true,
-      deck,
-      counts,
-      ease: computeDistribution([], { boundaries: easeBuckets }),
-      intervals: computeDistribution([], {
-        boundaries: intervalBuckets,
-        unitSuffix: "d",
-      }),
-    };
-  }
+  // NOTE: deliberately no `counts.total === 0` short-circuit. `total` is the
+  // storage-deck row count, the very number this tool cannot trust — a deck
+  // whose cards are currently borrowed by a filtered deck can report
+  // `total_in_deck: 0` while `deck:X` still matches every one of its cards.
+  // The `findCards` result below is the single emptiness gate, and it is
+  // derived from the same search the state counts use.
 
-  // Step 3: Get all card IDs for this deck (Anki's `deck:` query includes
-  // subdecks by default, so this already covers the whole subtree).
-  const escapedDeckName = deck.replace(/"/g, '\\"');
+  // Step 3: Get all card IDs for this deck. Anki's `deck:` term matches the
+  // deck AND its descendants (and cards pulled into a filtered deck from the
+  // subtree), so this single query already covers the whole subtree.
+  const deckScope = deckScopeQuery(deck);
   const cardIds = await client.invoke<number[]>("findCards", {
-    query: `"deck:${escapedDeckName}"`,
+    query: deckScope,
   });
+
+  // Unlike fetchCardStateCounts (which throws on ANY non-array), null/undefined
+  // is allowed through here to preserve the long-standing empty-deck path below.
+  if (cardIds != null && !Array.isArray(cardIds)) {
+    throw new Error("Invalid findCards response: expected array");
+  }
 
   if (!cardIds || cardIds.length === 0) {
     return {
       success: true,
       deck,
       counts,
+      states: emptyCardStateCounts(),
       ease: computeDistribution([], { boundaries: easeBuckets }),
       intervals: computeDistribution([], {
         boundaries: intervalBuckets,
@@ -198,31 +214,46 @@ export async function deckStats(
     };
   }
 
-  await onProgress?.(50);
+  await onProgress?.(40);
 
-  // Step 4: Get ease factors (divide by 1000!)
+  // Step 4: True card-state counts (5 `findCards` queries). These are what
+  // `counts` cannot give us: totals per state, ignoring due dates and daily
+  // limits.
+  const states = await fetchCardStateCounts(client, deckScope);
+
+  await onProgress?.(55);
+
+  // Step 5: Get ease factors (divide by 1000!)
   const easeFactorsRaw = await client.invoke<number[]>("getEaseFactors", {
     cards: cardIds,
   });
+
+  if (!Array.isArray(easeFactorsRaw)) {
+    throw new Error("Invalid getEaseFactors response: expected array");
+  }
 
   // Transform: divide by 1000 and filter invalid values
   const easeValues = easeFactorsRaw
     .map((e) => e / 1000) // 4100 → 4.1
     .filter((e) => e > 0); // Filter out invalid values (0 = new cards)
 
-  await onProgress?.(70);
+  await onProgress?.(75);
 
-  // Step 5: Get intervals (filter negatives = learning cards)
+  // Step 6: Get intervals (filter negatives = learning cards)
   const intervalsRaw = await client.invoke<number[]>("getIntervals", {
     cards: cardIds,
   });
+
+  if (!Array.isArray(intervalsRaw)) {
+    throw new Error("Invalid getIntervals response: expected array");
+  }
 
   // Transform: filter out negative values (learning cards in seconds)
   const intervalValues = intervalsRaw.filter((i) => i > 0); // Only review cards (positive = days)
 
   await onProgress?.(90);
 
-  // Step 6: Compute distributions
+  // Step 7: Compute distributions
   const ease = computeDistribution(easeValues, {
     boundaries: easeBuckets,
   });
@@ -236,6 +267,7 @@ export async function deckStats(
     success: true,
     deck,
     counts,
+    states,
     ease,
     intervals,
   };

--- a/src/mcp/primitives/essential/tools/deckActions/actions/listDecks.action.ts
+++ b/src/mcp/primitives/essential/tools/deckActions/actions/listDecks.action.ts
@@ -1,5 +1,6 @@
 import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
 import { DeckInfo, DeckStats } from "@/mcp/types/anki.types";
+import { getRootDeckNames } from "@/mcp/utils/deck-hierarchy.utils";
 
 /**
  * Parameters for listDecks action
@@ -15,8 +16,21 @@ export interface ListDecksParams {
 export interface ListDecksResult {
   success: boolean;
   decks: DeckInfo[];
+  /** Number of decks returned (child decks counted separately). */
   total: number;
   message?: string;
+  /**
+   * Collection-wide totals. The two field families are summed over different
+   * deck sets on purpose, because AnkiConnect reports them differently:
+   *
+   * - `total_cards` sums `total_in_deck`, which counts a deck's OWN cards, so
+   *   summing every deck yields the correct collection total.
+   * - `new_cards` / `learning_cards` / `review_cards` sum the scheduler's
+   *   due-today buckets, which are ALREADY rolled up over subdecks. Summing
+   *   every deck would count a parent's cards again for each child, so these
+   *   are summed over ROOT decks only — the same convention `collection_stats`
+   *   uses.
+   */
   summary?: {
     total_cards: number;
     new_cards: number;
@@ -26,7 +40,13 @@ export interface ListDecksResult {
 }
 
 /**
- * List all available Anki decks, optionally with statistics
+ * List all available Anki decks, optionally with statistics.
+ *
+ * The per-deck stats come straight from AnkiConnect's `getDeckStats`, i.e. the
+ * scheduler's due tree: **cards due today, capped by the deck's daily
+ * new/review limits**, suspended/buried excluded, rolled up over subdecks —
+ * the same numbers Anki's deck browser shows. They are not card totals. Use the
+ * `deckStats` tool (its `states` block) for true per-state card counts.
  *
  * @see https://git.sr.ht/~foosoft/anki-connect#decknames
  * @see https://git.sr.ht/~foosoft/anki-connect#getdeckstats
@@ -93,11 +113,25 @@ export async function listDecks(
       return { name };
     });
 
-    // Calculate summary totals
+    // Calculate summary totals.
+    //
+    // `total_cards` sums EVERY deck: `total_in_deck` counts a deck's own cards
+    // only, so the sum is the true collection total.
+    //
+    // The three scheduler buckets sum ROOT decks only. AnkiConnect already
+    // rolls those up over subdecks, so adding a parent and its children
+    // together counts the children's cards twice (a "German" + "German::Verbs"
+    // pair would report double the due cards). Same convention as
+    // `collection_stats`.
+    const rootDeckNames = new Set(getRootDeckNames(deckNames));
+
     summary = decks.reduce(
       (acc, deck) => {
-        if (deck.stats) {
-          acc.total_cards += deck.stats.total_cards;
+        if (!deck.stats) {
+          return acc;
+        }
+        acc.total_cards += deck.stats.total_cards;
+        if (rootDeckNames.has(deck.name)) {
           acc.new_cards += deck.stats.new_count;
           acc.learning_cards += deck.stats.learn_count;
           acc.review_cards += deck.stats.review_count;

--- a/src/mcp/primitives/essential/tools/get-cards.tool.ts
+++ b/src/mcp/primitives/essential/tools/get-cards.tool.ts
@@ -3,6 +3,7 @@ import { Tool } from "@rekog/mcp-nest";
 import { z } from "zod";
 import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
 import { AnkiCard, SimplifiedCard } from "@/mcp/types/anki.types";
+import { deckScopeQuery } from "@/mcp/utils/card-states.utils";
 import {
   extractRenderedCardContent,
   createErrorResponse,
@@ -104,9 +105,10 @@ export class GetCardsTool {
       let query = `${excludeSuspended}${stateQuery}`;
 
       if (deck_name) {
-        // Escape special characters in deck name for Anki search
-        const escapedDeckName = deck_name.replace(/"/g, '\\"');
-        query = `"deck:${escapedDeckName}" ${query}`;
+        // `deck_name` is a literal deck name, not a pattern — deckScopeQuery
+        // escapes `"`, `*`, `_` and `\` so a deck like "JLPT_N5" cannot also
+        // match a sibling "JLPT-N5".
+        query = `${deckScopeQuery(deck_name)} ${query}`;
       }
 
       // Find cards using AnkiConnect

--- a/src/mcp/primitives/essential/tools/get-due-cards.tool.ts
+++ b/src/mcp/primitives/essential/tools/get-due-cards.tool.ts
@@ -3,6 +3,7 @@ import { Tool } from "@rekog/mcp-nest";
 import { z } from "zod";
 import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
 import { AnkiCard, SimplifiedCard } from "@/mcp/types/anki.types";
+import { deckScopeQuery } from "@/mcp/utils/card-states.utils";
 import {
   extractRenderedCardContent,
   createErrorResponse,
@@ -100,9 +101,10 @@ export class GetDueCardsTool {
 
       let query = `-is:suspended (${states.join(" OR ")})`;
       if (deck_name) {
-        // Escape special characters in deck name for Anki search
-        const escapedDeckName = deck_name.replace(/"/g, '\\"');
-        query = `"deck:${escapedDeckName}" ${query}`;
+        // `deck_name` is a literal deck name, not a pattern — deckScopeQuery
+        // escapes `"`, `*`, `_` and `\` so a deck like "JLPT_N5" cannot also
+        // match a sibling "JLPT-N5".
+        query = `${deckScopeQuery(deck_name)} ${query}`;
       }
 
       // Find cards using AnkiConnect
@@ -128,8 +130,7 @@ export class GetDueCardsTool {
         const newOnlyStates = ["is:new"];
         let newQuery = `-is:suspended (${newOnlyStates.join(" OR ")})`;
         if (deck_name) {
-          const escapedDeckName = deck_name.replace(/"/g, '\\"');
-          newQuery = `"deck:${escapedDeckName}" ${newQuery}`;
+          newQuery = `${deckScopeQuery(deck_name)} ${newQuery}`;
         }
         try {
           const newIds = await this.ankiClient.invoke<number[]>("findCards", {

--- a/src/mcp/primitives/essential/tools/list-decks.tool.ts
+++ b/src/mcp/primitives/essential/tools/list-decks.tool.ts
@@ -14,7 +14,10 @@ export class ListDecksTool {
   @Tool({
     name: "listDecks",
     description:
-      "List all Anki decks, optionally with card count statistics for each deck. Remember to sync first at the start of a session for latest data.",
+      "List all Anki decks, optionally with per-deck study-queue statistics. " +
+      "IMPORTANT: those statistics are Anki's deck-browser numbers — cards DUE TODAY, capped by each deck's daily new/review limits, excluding suspended and buried cards — NOT totals per card state. " +
+      "Use the `deckStats` tool (its `states` block) or `collection_stats` for true card-state counts. " +
+      "Remember to sync first at the start of a session for latest data.",
     parameters: z.object({
       includeStats: z
         .boolean()
@@ -30,24 +33,80 @@ export class ListDecksTool {
             .object({
               deck_id: z.number(),
               name: z.string(),
-              new_count: z.number(),
-              learn_count: z.number(),
-              review_count: z.number(),
-              total_new: z.number(),
-              total_cards: z.number(),
+              new_count: z
+                .number()
+                .describe(
+                  "New cards due today, capped by the daily new-card limit. " +
+                    "Subdecks included. Not the total number of new cards.",
+                ),
+              learn_count: z
+                .number()
+                .describe(
+                  "Learning/relearning cards due now or today. Subdecks included.",
+                ),
+              review_count: z
+                .number()
+                .describe(
+                  "Review cards DUE TODAY, capped by the daily review limit. " +
+                    "Subdecks included. Not 'mature' cards and not all review cards.",
+                ),
+              total_new: z
+                .number()
+                .describe(
+                  "Misleading legacy name: same value as new_count (new cards " +
+                    "due today), NOT the total number of new cards.",
+                ),
+              total_cards: z
+                .number()
+                .describe(
+                  "Cards stored directly in this deck, subdecks NOT included, " +
+                    "suspended and buried included.",
+                ),
             })
-            .optional(),
+            .optional()
+            .describe(
+              "Study-queue counts from Anki's deck browser (due today, capped " +
+                "by daily limits) — not per-state card totals.",
+            ),
         }),
       ),
       total: z.number(),
       summary: z
         .object({
-          total_cards: z.number(),
-          new_cards: z.number(),
-          learning_cards: z.number(),
-          review_cards: z.number(),
+          total_cards: z
+            .number()
+            .describe(
+              "Total cards in the collection: sum of every deck's own card " +
+                "count (subdecks are separate rows, so nothing is missed or " +
+                "double-counted).",
+            ),
+          new_cards: z
+            .number()
+            .describe(
+              "New cards due across the collection today, capped by daily " +
+                "limits. Summed over ROOT decks only, because the per-deck " +
+                "counts are already rolled up over subdecks. Not the total " +
+                "number of new cards.",
+            ),
+          learning_cards: z
+            .number()
+            .describe(
+              "Learning/relearning cards due now or today across the " +
+                "collection. Summed over ROOT decks only, like new_cards.",
+            ),
+          review_cards: z
+            .number()
+            .describe(
+              "Review cards DUE TODAY across the collection, capped by daily " +
+                "limits. Summed over ROOT decks only, like new_cards. Not all " +
+                "review cards.",
+            ),
         })
-        .optional(),
+        .optional()
+        .describe(
+          "Collection-wide totals with study-queue semantics, not card-state " +
+            "totals. Use collection_stats for true per-state counts.",
+        ),
       message: z.string().optional(),
     }),
     annotations: {

--- a/src/mcp/types/anki.types.ts
+++ b/src/mcp/types/anki.types.ts
@@ -80,15 +80,31 @@ export interface DeckInfo {
 }
 
 /**
- * Deck statistics
+ * Deck statistics as surfaced by the `listDecks` tool.
+ *
+ * Mapped from {@link AnkiDeckStatsResponse}, so the same caveats apply: the
+ * three bucket counts are **due-today** numbers **capped by daily limits**
+ * (not card totals), rolled up over subdecks. The `total_*` field names are
+ * historical and do NOT mean "all cards in this state".
  */
 export interface DeckStats {
   deck_id: number;
   name: string;
+  /** New cards due today, capped by the daily new-card limit. Subdecks included. */
   new_count: number;
+  /** Learning/relearning cards due now or today. Subdecks included. */
   learn_count: number;
+  /** Review cards due today, capped by the daily review limit. Subdecks included. */
   review_count: number;
+  /**
+   * Misleading legacy name: a copy of {@link DeckStats.new_count}, i.e. new
+   * cards due today, NOT the total number of new cards in the deck.
+   */
   total_new: number;
+  /**
+   * AnkiConnect's `total_in_deck`: cards stored **directly** in this deck
+   * (subdecks NOT included), including suspended and buried.
+   */
   total_cards: number;
 }
 
@@ -96,10 +112,30 @@ export interface DeckStats {
  * Response structure from AnkiConnect getDeckStats action.
  * The response is a record keyed by deck ID (as string).
  *
- * Note: `total_in_deck` counts every card in the deck, while
- * `new_count`/`learn_count`/`review_count` come from the scheduler's due tree
- * and exclude suspended/buried cards — so the three buckets won't always sum
- * to `total_in_deck`.
+ * IMPORTANT — these are NOT card-state totals. AnkiConnect derives
+ * `new_count`/`learn_count`/`review_count` from the scheduler's due tree
+ * (`deck_due_tree()`), i.e. the exact numbers Anki's deck browser shows. They
+ * count cards **due to be studied today** and are **capped by the deck's daily
+ * new/review limits** (including limits inherited from parent decks):
+ *
+ * - `new_count` — new cards queued for today, capped by the new/day limit.
+ * - `learn_count` — intraday + interday learning/relearning cards due now or
+ *   today; the interday part is capped by the review/day limit.
+ * - `review_count` — review cards **due today only**, capped by the review/day
+ *   limit. Not "mature" cards, and not all review cards.
+ *
+ * Suspended and buried cards sit in queues the due tree never counts, so they
+ * are excluded from all three. The three buckets ARE rolled up over subdecks.
+ *
+ * `total_in_deck` differs in every respect: it is a plain row count of the cards
+ * stored **directly** in that deck (no subdecks) and it **does** include
+ * suspended/buried cards. So the three buckets will not sum to `total_in_deck`,
+ * and for a parent deck they can even exceed it.
+ *
+ * For true card-state counts use `fetchCardStateCounts` from
+ * `@/mcp/utils/card-states.utils`, which counts via Anki searches instead.
+ *
+ * @see https://docs.ankiweb.net/deck-options.html#daily-limits
  */
 export interface AnkiDeckStatsResponse {
   deck_id: number;

--- a/src/mcp/utils/__tests__/card-states.utils.spec.ts
+++ b/src/mcp/utils/__tests__/card-states.utils.spec.ts
@@ -1,0 +1,169 @@
+import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
+import {
+  deckScopeQuery,
+  emptyCardStateCounts,
+  fetchCardStateCounts,
+} from "@/mcp/utils/card-states.utils";
+
+jest.mock("@/mcp/clients/anki-connect.client");
+
+/**
+ * These expectations are HARDCODED on purpose. They are the authoritative pin
+ * for the search semantics documented in `card-states.utils.ts` — asserting
+ * against a shared constant would be self-referential and would let a bad edit
+ * sail through both sides at once.
+ *
+ * Reference: https://docs.ankiweb.net/searching.html#card-state and Anki's
+ * `rslib/src/search/sqlwriter.rs` (`write_state`), where `is:new`/`is:learn`/
+ * `is:review` are card-TYPE predicates (hence the explicit
+ * `-is:suspended -is:buried`) and `is:learn`/`is:review` overlap on relearning
+ * cards (hence `-is:learn` on the review filter).
+ */
+const EXPECTED_FILTERS = [
+  "is:new -is:suspended -is:buried",
+  "is:learn -is:suspended -is:buried",
+  "is:review -is:learn -is:suspended -is:buried",
+  "is:suspended",
+  "is:buried",
+];
+
+describe("card-states.utils", () => {
+  let client: jest.Mocked<AnkiConnectClient>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = new (
+      AnkiConnectClient as jest.Mock
+    )() as jest.Mocked<AnkiConnectClient>;
+  });
+
+  /** Collect the `query` of every `findCards` call, in order. */
+  function issuedQueries(): string[] {
+    return client.invoke.mock.calls
+      .filter(([action]) => action === "findCards")
+      .map(([, params]) => (params as { query: string }).query);
+  }
+
+  describe("deckScopeQuery", () => {
+    it("wraps a plain deck name in a quoted deck: term", () => {
+      expect(deckScopeQuery("German")).toBe('"deck:German"');
+    });
+
+    it("keeps :: separators unescaped so subdeck names still resolve", () => {
+      // Colons after the first one belong to the value, so escaping them would
+      // break every `Parent::Child` deck.
+      expect(deckScopeQuery("Japanese::JLPT N5")).toBe(
+        '"deck:Japanese::JLPT N5"',
+      );
+    });
+
+    it('escapes double quotes: Say "hi"', () => {
+      expect(deckScopeQuery('Say "hi"')).toBe('"deck:Say \\"hi\\""');
+    });
+
+    it("escapes the _ wildcard so JLPT_N5 cannot match siblings", () => {
+      // Unescaped, `_` matches any single character — `JLPT_N5` would also
+      // match a sibling deck named `JLPT-N5`.
+      expect(deckScopeQuery("JLPT_N5")).toBe('"deck:JLPT\\_N5"');
+    });
+
+    it("escapes the * wildcard", () => {
+      expect(deckScopeQuery("A*B")).toBe('"deck:A\\*B"');
+    });
+
+    it("escapes backslashes so the term stays a valid escape sequence", () => {
+      // Unescaped, `\P` is an invalid escape and AnkiConnect rejects the search.
+      expect(deckScopeQuery("Math\\Physics")).toBe('"deck:Math\\\\Physics"');
+    });
+
+    it("escapes every special character in one pass without double-escaping", () => {
+      expect(deckScopeQuery('a\\b"c*d_e')).toBe('"deck:a\\\\b\\"c\\*d\\_e"');
+    });
+  });
+
+  describe("fetchCardStateCounts", () => {
+    it("issues the five state searches in a fixed order, unscoped", async () => {
+      client.invoke.mockResolvedValue([]);
+
+      await fetchCardStateCounts(client);
+
+      expect(issuedQueries()).toEqual(EXPECTED_FILTERS);
+    });
+
+    it("prefixes every search with the supplied scope", async () => {
+      client.invoke.mockResolvedValue([]);
+
+      await fetchCardStateCounts(client, deckScopeQuery("German"));
+
+      expect(issuedQueries()).toEqual([
+        '"deck:German" is:new -is:suspended -is:buried',
+        '"deck:German" is:learn -is:suspended -is:buried',
+        '"deck:German" is:review -is:learn -is:suspended -is:buried',
+        '"deck:German" is:suspended',
+        '"deck:German" is:buried',
+      ]);
+    });
+
+    it("maps each search result onto its own state", async () => {
+      client.invoke.mockImplementation((_action: string, params?: any) => {
+        const byQuery: Record<string, number[]> = {
+          "is:new -is:suspended -is:buried": [1, 2, 3],
+          "is:learn -is:suspended -is:buried": [4, 5],
+          "is:review -is:learn -is:suspended -is:buried": [6, 7, 8, 9],
+          "is:suspended": [10],
+          "is:buried": [11, 12],
+        };
+        return Promise.resolve(byQuery[params.query] ?? []);
+      });
+
+      await expect(fetchCardStateCounts(client)).resolves.toEqual({
+        new: 3,
+        learning: 2,
+        review: 4,
+        suspended: 1,
+        buried: 2,
+      });
+    });
+
+    it("returns zeros when every search comes back empty", async () => {
+      client.invoke.mockResolvedValue([]);
+
+      await expect(fetchCardStateCounts(client)).resolves.toEqual(
+        emptyCardStateCounts(),
+      );
+    });
+
+    it("throws instead of silently reporting 0 on a non-array response", async () => {
+      client.invoke.mockImplementation((_action: string, params?: any) =>
+        Promise.resolve(params.query === "is:suspended" ? {} : []),
+      );
+
+      await expect(fetchCardStateCounts(client)).rejects.toThrow(
+        'Invalid findCards response for state "suspended": expected array',
+      );
+    });
+
+    it("propagates AnkiConnect failures to the caller", async () => {
+      client.invoke.mockRejectedValue(new Error("connection refused"));
+
+      await expect(fetchCardStateCounts(client)).rejects.toThrow(
+        "connection refused",
+      );
+    });
+  });
+
+  describe("emptyCardStateCounts", () => {
+    it("returns a fresh zeroed object each call", () => {
+      const first = emptyCardStateCounts();
+      first.new = 99;
+
+      expect(emptyCardStateCounts()).toEqual({
+        new: 0,
+        learning: 0,
+        review: 0,
+        suspended: 0,
+        buried: 0,
+      });
+    });
+  });
+});

--- a/src/mcp/utils/card-states.utils.ts
+++ b/src/mcp/utils/card-states.utils.ts
@@ -1,0 +1,295 @@
+import { z } from "zod";
+import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
+
+/**
+ * Card counting for the stats tools.
+ *
+ * This module deliberately owns BOTH halves of the deck-count story:
+ *
+ * - the scheduler's **due tree** counts (`dueTreeCountsSchema`) that AnkiConnect
+ *   returns from `getDeckStats`, and
+ * - the true **card-state** counts (`cardStatesSchema`, `fetchCardStateCounts`)
+ *   computed from Anki searches.
+ *
+ * They are constantly mistaken for one another, so their wording lives side by
+ * side here and is reused verbatim by every tool surface — that is what stops
+ * the two descriptions drifting apart again.
+ */
+
+// ---------------------------------------------------------------------------
+// Card states (search-derived)
+// ---------------------------------------------------------------------------
+
+/**
+ * True card-state counts, derived from Anki searches rather than from the
+ * scheduler's due tree.
+ *
+ * Unlike AnkiConnect's `getDeckStats` buckets, these numbers are NOT filtered
+ * by due date and NOT capped by daily new/review limits — they answer "how many
+ * cards are in this state" rather than "how many will I study today".
+ *
+ * Single source of truth: the TypeScript type is derived from this schema, so
+ * the two can't fall out of sync.
+ */
+export const cardStateCountsSchema = z.object({
+  new: z
+    .number()
+    .describe(
+      "Cards never studied, excluding suspended and buried. True count: " +
+        "not filtered by due date and not capped by the daily new-card limit.",
+    ),
+  learning: z
+    .number()
+    .describe(
+      "Cards in learning or relearning (lapsed cards are counted here), " +
+        "excluding suspended and buried.",
+    ),
+  review: z
+    .number()
+    .describe(
+      "Cards in the review state that are not relearning, excluding " +
+        "suspended and buried. Young and mature, due or not due.",
+    ),
+  suspended: z
+    .number()
+    .describe("Suspended cards, whatever their underlying state."),
+  buried: z
+    .number()
+    .describe(
+      "Buried cards (manually or automatically), whatever their underlying state.",
+    ),
+});
+
+/** True card-state counts. Derived from {@link cardStateCountsSchema}. */
+export type CardStateCounts = z.infer<typeof cardStateCountsSchema>;
+
+/**
+ * Zod schema for the `states` block, shared by `deckStats` and
+ * `collection_stats` so both surfaces describe the fields identically.
+ *
+ * @param scope Human-readable scope inserted into the block description, e.g.
+ *   `"this deck and all of its subdecks"` or `"the whole collection"`.
+ */
+export function cardStatesSchema(scope: string) {
+  return cardStateCountsSchema.describe(
+    `True card-state counts for ${scope}, computed from Anki searches ` +
+      "(is:new / is:learn / is:review / is:suspended / is:buried). " +
+      "Unaffected by due dates and daily limits — use these to answer " +
+      '"how many cards are in state X", and `counts` to answer ' +
+      '"what will I study today". The five values are mutually exclusive ' +
+      "and together cover every card in scope.",
+  );
+}
+
+/**
+ * Search fragment per card state. `satisfies Record<keyof CardStateCounts, …>`
+ * makes the compiler reject a missing or misspelled state, and the declaration
+ * order below is the order the queries are issued in (JS preserves insertion
+ * order for string keys), so call sequences stay deterministic.
+ *
+ * Semantics verified against Anki's search implementation
+ * (`rslib/src/search/sqlwriter.rs`, `write_state`) and the manual's
+ * "Card state" section (https://docs.ankiweb.net/searching.html):
+ *
+ * - `is:new`       → `c.type = New`
+ * - `is:learn`     → `c.type in (Learn, Relearn)`
+ * - `is:review`    → `c.type in (Review, Relearn)`
+ * - `is:suspended` → `c.queue = Suspended`
+ * - `is:buried`    → `c.queue in (SchedBuried, UserBuried)`
+ *
+ * Because `is:learn` and `is:review` overlap on relearning (lapsed) cards, the
+ * review filter subtracts `is:learn` — the manual documents `-is:learn is:review`
+ * as "review cards, not including lapsed cards". Lapsed cards are therefore
+ * reported under `learning`, matching how Anki's deck browser groups them.
+ *
+ * `is:new`/`is:learn`/`is:review` are card-TYPE predicates, so they still match
+ * suspended and buried cards; the three active buckets subtract them explicitly.
+ * Since `suspended` and `buried` are disjoint queue states, the five filters
+ * cover every card exactly once:
+ * `new + learning + review + suspended + buried === cards matched by the scope`.
+ */
+const CARD_STATE_QUERIES = {
+  new: "is:new -is:suspended -is:buried",
+  learning: "is:learn -is:suspended -is:buried",
+  review: "is:review -is:learn -is:suspended -is:buried",
+  suspended: "is:suspended",
+  buried: "is:buried",
+} satisfies Record<keyof CardStateCounts, string>;
+
+/** All-zero state counts, for empty decks / empty collections. */
+export function emptyCardStateCounts(): CardStateCounts {
+  return { new: 0, learning: 0, review: 0, suspended: 0, buried: 0 };
+}
+
+/**
+ * Characters that keep a special meaning **inside** double quotes in an Anki
+ * search and therefore need a backslash: `\` (the escape character itself),
+ * `"`, and the `*` / `_` wildcards. Quoting the term already handles spaces,
+ * parentheses, leading hyphens and the `and`/`or` keywords.
+ *
+ * Colons are deliberately NOT escaped: in a `deck:` term everything after the
+ * first colon is the value, so `Parent::Child` must pass through untouched.
+ *
+ * @see https://docs.ankiweb.net/searching.html#matching-special-characters
+ */
+const ANKI_SEARCH_SPECIALS = /[\\"*_]/g;
+
+/**
+ * Build the `deck:` scope term for a deck-scoped query.
+ *
+ * Anki's `deck:` term matches the deck AND all of its descendants by default,
+ * and also matches cards temporarily pulled into a filtered deck from that
+ * subtree (`c.odid`), so a single term covers the whole subtree.
+ *
+ * The name is escaped so it is matched literally: without this, a deck called
+ * `JLPT_N5` would also match `JLPT-N5`, `A*B` would match far too much, and a
+ * name containing a backslash would produce an invalid escape sequence that
+ * AnkiConnect rejects outright. Callers resolve the name against
+ * `deckNamesAndIds` first, so it is always a literal deck name, never a pattern.
+ */
+export function deckScopeQuery(deckName: string): string {
+  return `"deck:${deckName.replace(ANKI_SEARCH_SPECIALS, (char) => `\\${char}`)}"`;
+}
+
+/**
+ * Count cards by true state via `findCards`.
+ *
+ * Issues one `findCards` call per state (5 total), sequentially — the
+ * AnkiConnect client serializes requests through a mutex anyway, so parallelism
+ * would buy nothing while consuming queue depth.
+ *
+ * @param client AnkiConnect client
+ * @param scope Optional search prefix limiting the counts, e.g. the result of
+ *   {@link deckScopeQuery}. Omit to count across the whole collection.
+ * @throws if AnkiConnect returns a non-array for any of the queries — better a
+ *   surfaced error than a silently plausible zero.
+ *
+ * @see https://docs.ankiweb.net/searching.html#card-state
+ * @see https://git.sr.ht/~foosoft/anki-connect#findcards
+ */
+export async function fetchCardStateCounts(
+  client: AnkiConnectClient,
+  scope?: string,
+): Promise<CardStateCounts> {
+  const prefix = scope ? `${scope} ` : "";
+  const counts = emptyCardStateCounts();
+
+  const entries = Object.entries(CARD_STATE_QUERIES) as [
+    keyof CardStateCounts,
+    string,
+  ][];
+
+  for (const [state, filter] of entries) {
+    const cardIds = await client.invoke<number[]>("findCards", {
+      query: `${prefix}${filter}`,
+    });
+
+    if (!Array.isArray(cardIds)) {
+      throw new Error(
+        `Invalid findCards response for state "${state}": expected array`,
+      );
+    }
+
+    counts[state] = cardIds.length;
+  }
+
+  return counts;
+}
+
+// ---------------------------------------------------------------------------
+// Due-tree counts (getDeckStats-derived)
+// ---------------------------------------------------------------------------
+
+/**
+ * The `total === new + learning + review + other` relationship, stated
+ * honestly. `other` is computed as a clamped difference, so the identity can
+ * break in the rare cases where the scheduler's buckets exceed the storage-deck
+ * row count.
+ */
+export const DUE_TREE_INVARIANT_NOTE =
+  "Normally total === new + learning + review + other; `other` is clamped at 0, " +
+  "so in rare filtered-deck / inherited-limit cases the sum can exceed total.";
+
+/**
+ * Field schemas for a scheduler due-tree count block, shared by `deckStats`,
+ * `collection_stats.counts` and `collection_stats.per_deck` so all three
+ * describe the same numbers the same way.
+ *
+ * @param totalDescription Scope-specific description for `total` — the only
+ *   field whose meaning changes between surfaces.
+ */
+export function dueTreeCountsShape(totalDescription: string) {
+  return {
+    total: z.number().describe(totalDescription),
+    new: z
+      .number()
+      .describe(
+        "New cards queued for study TODAY, capped by each deck's daily " +
+          "new-card limit. This is not the total number of new cards — " +
+          "see states.new.",
+      ),
+    learning: z
+      .number()
+      .describe(
+        "Learning/relearning cards due now or today, the interday part " +
+          "capped by the daily review limit.",
+      ),
+    review: z
+      .number()
+      .describe(
+        "Review cards DUE TODAY, capped by each deck's daily review limit. " +
+          "Not 'mature' cards and not all review cards — cards scheduled " +
+          "for a future day are excluded. See states.review.",
+      ),
+    other: z
+      .number()
+      .describe(
+        "Arithmetic remainder: total - new - learning - review. NOT a card " +
+          "state. Dominated by review cards not due today plus new cards " +
+          "beyond the daily new limit; suspended and buried cards also land " +
+          "here. It can also reflect the mismatch between total (counted by " +
+          "storage deck) and the scheduler buckets when a filtered deck has " +
+          "borrowed cards from this deck. Use `states` for real per-state counts.",
+      ),
+  };
+}
+
+/**
+ * Scheduler due-tree counts: the `getDeckStats` buckets plus the residual
+ * `other`. Derived from {@link dueTreeCountsShape} so the tools' result
+ * interfaces can't drift from the schemas they are validated against.
+ *
+ * Semantics — these are TODAY'S STUDY QUEUE, not card totals: due-today only,
+ * capped by daily new/review limits, suspended/buried excluded, rolled up over
+ * subdecks. `other` is a clamped remainder. See {@link DUE_TREE_INVARIANT_NOTE}
+ * and the per-field `.describe()` text in {@link dueTreeCountsShape}.
+ */
+export type DueTreeCounts = {
+  [K in keyof ReturnType<typeof dueTreeCountsShape>]: z.infer<
+    ReturnType<typeof dueTreeCountsShape>[K]
+  >;
+};
+
+/**
+ * Zod schema for a scheduler due-tree count block.
+ *
+ * @param options.scope Human-readable scope, e.g. `"this deck and its descendants"`.
+ * @param options.total Description for the `total` field.
+ * @param options.note Optional extra sentence appended to the block description.
+ */
+export function dueTreeCountsSchema(options: {
+  scope: string;
+  total: string;
+  note?: string;
+}) {
+  return z
+    .object(dueTreeCountsShape(options.total))
+    .describe(
+      `Today's study queue for ${options.scope}, exactly as shown in Anki's ` +
+        "deck browser: due-today counts capped by the daily new/review limits " +
+        "(parent limits included), always excluding suspended and buried cards. " +
+        "These are NOT card totals — use `states`. " +
+        (options.note ? `${options.note} ` : "") +
+        DUE_TREE_INVARIANT_NOTE,
+    );
+}

--- a/src/mcp/utils/deck-hierarchy.utils.ts
+++ b/src/mcp/utils/deck-hierarchy.utils.ts
@@ -6,9 +6,13 @@
  * AnkiConnect's `getDeckStats` returns in `new_count` / `learn_count` /
  * `review_count`). However `total_in_deck` from the same response is the
  * count of cards stored *directly* in that deck's table — it does NOT
- * include descendants. To keep per-deck arithmetic consistent
- * (`total >= new + learning + review`) we need to roll up `total_in_deck`
- * the same way.
+ * include descendants. Rolling up `total_in_deck` the same way keeps per-deck
+ * arithmetic sane, so `total >= new + learning + review` normally holds.
+ *
+ * It is NOT guaranteed, though: the buckets are due-today counts drawn from the
+ * scheduler while `total_in_deck` counts rows by storage deck, so a filtered
+ * deck that has borrowed cards can push the buckets above `total`. Callers
+ * clamp the derived `other` bucket at 0 for exactly that reason.
  */
 
 /**

--- a/src/test-fixtures/test-helpers.ts
+++ b/src/test-fixtures/test-helpers.ts
@@ -29,3 +29,53 @@ export function createMockContext() {
     mcpRequest: {} as any,
   };
 }
+
+/**
+ * The `findCards` queries `fetchCardStateCounts` issues, in emission order.
+ * Mirrors `CARD_STATE_QUERIES` in `@/mcp/utils/card-states.utils`; the
+ * authoritative assertions on those literals live in
+ * `src/mcp/utils/__tests__/card-states.utils.spec.ts`, so this copy only has to
+ * be good enough to route mock responses.
+ */
+export const CARD_STATE_QUERY_FILTERS = [
+  "is:new -is:suspended -is:buried",
+  "is:learn -is:suspended -is:buried",
+  "is:review -is:learn -is:suspended -is:buried",
+  "is:suspended",
+  "is:buried",
+] as const;
+
+/** Card IDs to hand back per card state, used to build `findCards` mocks. */
+export interface StateCardIds {
+  new?: number[];
+  learning?: number[];
+  review?: number[];
+  suspended?: number[];
+  buried?: number[];
+}
+
+/**
+ * Resolve a `findCards` query to a card-ID array for stats-tool tests.
+ *
+ * State queries (optionally prefixed with a `deck:` scope) return their slice;
+ * anything else — the plain `"deck:X"` / `deck:*` listing query — returns
+ * `allCardIds`.
+ */
+export function findCardsFor(
+  query: string,
+  allCardIds: number[],
+  states: StateCardIds = {},
+): number[] {
+  const byState = [
+    states.new,
+    states.learning,
+    states.review,
+    states.suspended,
+    states.buried,
+  ];
+  const index = CARD_STATE_QUERY_FILTERS.findIndex(
+    (filter) => query === filter || query.endsWith(` ${filter}`),
+  );
+  if (index === -1) return allCardIds;
+  return byState[index] ?? [];
+}

--- a/test/e2e/stats-tools.e2e-spec.ts
+++ b/test/e2e/stats-tools.e2e-spec.ts
@@ -130,6 +130,41 @@ describe("E2E: Stats Tools (STDIO)", () => {
       expect(counts.review).toBe(0);
     });
 
+    it("should return true card-state counts for test deck", () => {
+      const result = callTool("deckStats", { deck: testDeck1.deckName });
+
+      // The fixture adds 10 Basic notes (1 card each) and never studies,
+      // suspends or buries them, so every card is in the New state.
+      expect(result.states).toEqual({
+        new: 10,
+        learning: 0,
+        review: 0,
+        suspended: 0,
+        buried: 0,
+      });
+    });
+
+    it("states should partition every card in the deck", () => {
+      const result = callTool("deckStats", { deck: testDeck1.deckName });
+
+      const counts = result.counts as Record<string, number>;
+      const states = result.states as Record<string, number>;
+
+      // The five states are mutually exclusive and cover every card matched
+      // by `deck:<name>` — nothing double-counted, nothing missed.
+      // stateSum === counts.total holds only while no e2e fixture uses
+      // filtered decks: `states` follows the search (odid included), while
+      // `counts.total` follows storage decks. A filtered deck would split them.
+      const stateSum =
+        states.new +
+        states.learning +
+        states.review +
+        states.suspended +
+        states.buried;
+
+      expect(stateSum).toBe(counts.total);
+    });
+
     it("should handle new cards with no ease data", () => {
       const result = callTool("deckStats", { deck: testDeck1.deckName });
 
@@ -289,6 +324,55 @@ describe("E2E: Stats Tools (STDIO)", () => {
 
       expect(counts.total).toBeGreaterThanOrEqual(testDeckTotals.total);
       expect(counts.new).toBeGreaterThanOrEqual(testDeckTotals.new);
+    });
+
+    it("should report collection-wide card states that partition the collection", () => {
+      const result = callTool("collection_stats");
+
+      const counts = result.counts as Record<string, number>;
+      const states = result.states as Record<string, number>;
+
+      for (const key of ["new", "learning", "review", "suspended", "buried"]) {
+        expect(states).toHaveProperty(key);
+        expect(states[key]).toBeGreaterThanOrEqual(0);
+      }
+
+      // The two numbers come from completely independent code paths —
+      // `counts.total` sums getDeckStats' per-deck row counts over root decks,
+      // while `states` counts via five Anki searches. They must agree —
+      // but only while no e2e fixture uses filtered decks, which would
+      // split the two counting bases (search vs storage deck).
+      const stateSum =
+        states.new +
+        states.learning +
+        states.review +
+        states.suspended +
+        states.buried;
+
+      expect(stateSum).toBe(counts.total);
+
+      // Both fixture decks (10 new cards each) are in the collection, and
+      // nothing in this suite studies them.
+      expect(states.new).toBeGreaterThanOrEqual(20);
+    });
+
+    it("collection states should account for both fixture decks", () => {
+      const deck1 = callTool("deckStats", { deck: testDeck1.deckName });
+      const deck2 = callTool("deckStats", { deck: testDeck2.deckName });
+      const collection = callTool("collection_stats");
+
+      const deck1States = deck1.states as Record<string, number>;
+      const deck2States = deck2.states as Record<string, number>;
+      const collectionStates = collection.states as Record<string, number>;
+
+      // Deck-scoped state counts must roll into the collection-wide ones.
+      for (const key of ["new", "learning", "review", "suspended", "buried"]) {
+        expect(collectionStates[key]).toBeGreaterThanOrEqual(
+          deck1States[key] + deck2States[key],
+        );
+      }
+
+      expect(deck1States.new + deck2States.new).toBe(20);
     });
 
     it("should accept custom ease buckets", () => {

--- a/test/e2e/stats-tools.http.e2e-spec.ts
+++ b/test/e2e/stats-tools.http.e2e-spec.ts
@@ -135,6 +135,41 @@ describe("E2E: Stats Tools (HTTP Streamable)", () => {
       expect(counts.review).toBe(0);
     });
 
+    it("should return true card-state counts for test deck", () => {
+      const result = callTool("deckStats", { deck: testDeck1.deckName });
+
+      // The fixture adds 10 Basic notes (1 card each) and never studies,
+      // suspends or buries them, so every card is in the New state.
+      expect(result.states).toEqual({
+        new: 10,
+        learning: 0,
+        review: 0,
+        suspended: 0,
+        buried: 0,
+      });
+    });
+
+    it("states should partition every card in the deck", () => {
+      const result = callTool("deckStats", { deck: testDeck1.deckName });
+
+      const counts = result.counts as Record<string, number>;
+      const states = result.states as Record<string, number>;
+
+      // The five states are mutually exclusive and cover every card matched
+      // by `deck:<name>` — nothing double-counted, nothing missed.
+      // stateSum === counts.total holds only while no e2e fixture uses
+      // filtered decks: `states` follows the search (odid included), while
+      // `counts.total` follows storage decks. A filtered deck would split them.
+      const stateSum =
+        states.new +
+        states.learning +
+        states.review +
+        states.suspended +
+        states.buried;
+
+      expect(stateSum).toBe(counts.total);
+    });
+
     it("should handle new cards with no ease data", () => {
       const result = callTool("deckStats", { deck: testDeck1.deckName });
 
@@ -294,6 +329,55 @@ describe("E2E: Stats Tools (HTTP Streamable)", () => {
 
       expect(counts.total).toBeGreaterThanOrEqual(testDeckTotals.total);
       expect(counts.new).toBeGreaterThanOrEqual(testDeckTotals.new);
+    });
+
+    it("should report collection-wide card states that partition the collection", () => {
+      const result = callTool("collection_stats");
+
+      const counts = result.counts as Record<string, number>;
+      const states = result.states as Record<string, number>;
+
+      for (const key of ["new", "learning", "review", "suspended", "buried"]) {
+        expect(states).toHaveProperty(key);
+        expect(states[key]).toBeGreaterThanOrEqual(0);
+      }
+
+      // The two numbers come from completely independent code paths —
+      // `counts.total` sums getDeckStats' per-deck row counts over root decks,
+      // while `states` counts via five Anki searches. They must agree —
+      // but only while no e2e fixture uses filtered decks, which would
+      // split the two counting bases (search vs storage deck).
+      const stateSum =
+        states.new +
+        states.learning +
+        states.review +
+        states.suspended +
+        states.buried;
+
+      expect(stateSum).toBe(counts.total);
+
+      // Both fixture decks (10 new cards each) are in the collection, and
+      // nothing in this suite studies them.
+      expect(states.new).toBeGreaterThanOrEqual(20);
+    });
+
+    it("collection states should account for both fixture decks", () => {
+      const deck1 = callTool("deckStats", { deck: testDeck1.deckName });
+      const deck2 = callTool("deckStats", { deck: testDeck2.deckName });
+      const collection = callTool("collection_stats");
+
+      const deck1States = deck1.states as Record<string, number>;
+      const deck2States = deck2.states as Record<string, number>;
+      const collectionStates = collection.states as Record<string, number>;
+
+      // Deck-scoped state counts must roll into the collection-wide ones.
+      for (const key of ["new", "learning", "review", "suspended", "buried"]) {
+        expect(collectionStates[key]).toBeGreaterThanOrEqual(
+          deck1States[key] + deck2States[key],
+        );
+      }
+
+      expect(deck1States.new + deck2States.new).toBe(20);
     });
 
     it("should accept custom ease buckets", () => {


### PR DESCRIPTION
Fixes #50.

## Problem

`deckStats` / `collection_stats` described `counts.review` as "review cards (mature)" and `counts.other` as "typically suspended or buried". In reality, AnkiConnect's `getDeckStats` numbers come from the scheduler's **due tree**: cards due *today*, capped by daily limits. `other` (= `total − new − learning − review`) is dominated by review-state cards not due today plus new cards beyond the daily new limit. An AI reading the old descriptions confidently reported wrong numbers — exactly what the issue reporter hit.

## Changes

- **Descriptions corrected on every surface** (tool schemas, TS types, `anki.types.ts`, README, manifest blurbs). The unconditional `total == new + learning + review + other` invariant is also softened — `other` is clamped at 0 and filtered-deck borrowing can break the identity.
- **New `states` block** with true card-state counts via Anki searches (`new` / `learning` / `review` / `suspended` / `buried`) — unaffected by due dates and daily limits. Per-deck on `deckStats`, collection-level on `collection_stats` (per-deck states deliberately omitted to keep response payload small). Query semantics verified against Anki's `rslib/src/search/sqlwriter.rs`: `is:new/learn/review` are card-*type* predicates that also match suspended/buried cards, so the queries carry explicit exclusions; the five values are mutually exclusive and exhaustive over the scope (relearning counts as `learning`, matching the deck browser).
- **Shared source of truth**: `src/mcp/utils/card-states.utils.ts` holds the queries, Zod schemas, and inferred types for both the card-state and due-tree vocabularies, so the two can't drift apart again.
- **`listDecks` summary bugfix**: bucket sums no longer double-count subdecks (per-deck buckets are already rolled up; summary now sums root decks only). Numbers shrink for collections with subdecks — they were inflated before.
- **Deck-name escaping hardened** (`deckStats`, `collection_stats`, `get_cards`, `get_due_cards`): `_`, `*`, `\` now escaped as literals (previously `JLPT_N5` silently over-matched sibling decks; `Math\Physics` errored). `::` passthrough preserved.
- **Stricter payload validation** on `findCards` / `getEaseFactors` / `getIntervals` (throw instead of silent zeros); removed a `counts.total === 0` short-circuit that zeroed `states` for decks whose cards sit in filtered decks.

## Compatibility

`counts` keys unchanged on all surfaces — `states` is purely additive. Behavioral deltas are the two intentional bugfixes above (listDecks summary, escaping).

## Testing

- Unit: 74 suites / 1315 tests green; new `card-states.utils.spec.ts` pins the exact query literals (incl. the `-is:learn` subtlety) and escaping cases; regression tests for filtered-deck borrowing and subdeck double-counting.
- E2E: `states` assertions added to both stats e2e specs (the fixture deck name `STATS_E2E_<uid>` exercises the `\_` escape against real AnkiConnect). Note: `stats-tools.e2e-spec.ts` is not matched by `e2e:full:local`'s test pattern — run `npm run e2e:test`.

## Known follow-ups (out of scope, found during review)

- `review_stats` doesn't reject invalid `start_date` (pre-existing e2e failure on clean main).
- `e2e:full:local` silently skips 3 spec files without `.http.`/`.stdio.` infix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013x5wZAZ5vtMRWpEUk6gzjx