### PR TITLE
fix(tunnel): treat IDLE_TIMEOUT (4010) as a permanent close code

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "anki-mcp-server",
   "display_name": "Anki MCP Server",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "license": "MIT",
   "description": "Model Context Protocol server for Anki spaced repetition flashcard application",
   "long_description": "Transform your Anki experience with natural language interaction - like having a private tutor. This MCP server enables AI assistants to interact with Anki, allowing them to explain concepts, make learning more engaging, provide context, and adapt to your learning style. Features include review sessions, deck management, note creation and editing, and more.\n\nRequires Anki with the AnkiConnect plugin installed.",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ankimcp/anki-mcp-server",
   "mcpName": "ai.ankimcp/anki-mcp-server",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Model Context Protocol server for Anki - enables AI assistants to interact with your Anki flashcards",
   "author": "Anatoly Tarnavsky",
   "private": false,

--- a/src/tunnel/tunnel.client.ts
+++ b/src/tunnel/tunnel.client.ts
@@ -636,7 +636,8 @@ export class TunnelClient extends EventEmitter {
       code === TunnelCloseCodes.NORMAL ||
       code === TunnelCloseCodes.ACCOUNT_DELETED ||
       code === TunnelCloseCodes.SESSION_REPLACED ||
-      code === TunnelCloseCodes.TOKEN_REVOKED
+      code === TunnelCloseCodes.TOKEN_REVOKED ||
+      code === TunnelCloseCodes.IDLE_TIMEOUT
     );
   }
 
@@ -659,6 +660,11 @@ export class TunnelClient extends EventEmitter {
         case TunnelCloseCodes.SESSION_REPLACED:
           this.logger.warn(
             "Disconnected: another device connected. Run `ankimcp --tunnel` to reconnect.",
+          );
+          break;
+        case TunnelCloseCodes.IDLE_TIMEOUT:
+          this.logger.warn(
+            "Disconnected after inactivity (free tier). Run `ankimcp --tunnel` to reconnect.",
           );
           break;
         case TunnelCloseCodes.TOKEN_REVOKED:

--- a/src/tunnel/tunnel.protocol.ts
+++ b/src/tunnel/tunnel.protocol.ts
@@ -101,6 +101,8 @@ export const TunnelCloseCodes = {
   SERVICE_UNAVAILABLE: 4008,
   /** Server shutting down gracefully */
   SHUTDOWN: 4009,
+  /** Free-tier tunnel idle for too long (no forwarded MCP requests) */
+  IDLE_TIMEOUT: 4010,
 } as const;
 
 export type TunnelCloseCode =


### PR DESCRIPTION
Free-tier tunnels are disconnected server-side after 12h of inactivity. The CLI now recognizes close code 4010 and does not attempt to auto-reconnect, mirroring SESSION_REPLACED (4005).